### PR TITLE
Pass route params to handlers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ fastify.listen(3000, err => {
 
 In this case there won't be any global handler, so it will respond with a 404 error on every unregistered route, closing the incoming upgrade connection requests.
 
+The route handler receives route params as a third argument:
+
+```js
+fastify.get('/ws/:id', { websocket: true }, (connection, req, params) => {
+  connection.write(`hi on stream ${params.id}`)
+})
+```
+
 However you can still pass a default global handler, that will be used as default handler.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ function fastifyWebsocket (fastify, opts, next) {
         throw new Error('invalid wsHandler function')
       }
 
-      router.on('GET', routeOptions.path, (req, _) => {
-        const result = wsHandler(req[kWs], req)
+      router.on('GET', routeOptions.path, (req, _, params) => {
+        const result = wsHandler(req[kWs], req, params)
 
         if (result && typeof result.catch === 'function') {
           result.catch((err) => req[kWs].destroy(err))

--- a/test/router.js
+++ b/test/router.js
@@ -286,3 +286,32 @@ test(`Should return 404 on http request`, t => {
     t.end()
   })
 })
+
+test('Should pass route params to handlers', t => {
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+  fastify.get('/ws/:id', { websocket: true }, (conn, req, params) => {
+    conn.write(params.id)
+    conn.end()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    const client = websocket(
+      'ws://localhost:' + (fastify.server.address()).port + '/ws/foo'
+    )
+    t.tearDown(client.destroy.bind(client))
+
+    client.setEncoding('utf8')
+    // client.write('hello server')
+
+    client.once('data', chunk => {
+      t.equal(chunk, 'foo')
+      client.end()
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
The `find-my-way` router already supports parsing route params.This PR simply passes the extracted route params on into the route handler, so that they can be used and don't have to be parsed again.