### PR TITLE
Migrate to ws (continue)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "12"
   - "10"
   - "8"
-  - "6"
 install:
   - npm install
 notifications:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/) [![Build Status](https://travis-ci.org/fastify/fastify-websocket.svg?branch=master)](https://travis-ci.org/fastify/fastify-websocket) [![Greenkeeper badge](https://badges.greenkeeper.io/fastify/fastify-websocket.svg)](https://greenkeeper.io/)
 
 WebSocket support for [Fastify](https://github.com/fastify/fastify).
-Built upon [websocket-stream](http://npm.im/websocket-stream).
+Built upon [ws](https://www.npmjs.com/package/ws).
 
 ## Install
 
@@ -161,7 +161,7 @@ fastify.listen(3000, err => {
 
 ## Options :
 
-`fastify-websocket` accept the same options as [`websocket-stream`](https://github.com/maxogden/websocket-stream#options) and as [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :
+`fastify-websocket` accept the same options as [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :
 
 - `objectMode` - Send each chunk on its own, and do not try to pack them in a single websocket frame.
 - `host` - The hostname where to bind the server.
@@ -176,7 +176,7 @@ fastify.listen(3000, err => {
 - `perMessageDeflate` - Enable/disable permessage-deflate.
 - `maxPayload` - The maximum allowed message size in bytes.
 
-For more informations you can check [`ws` options documentation](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) and [`websocket-stream` options documentation](https://github.com/maxogden/websocket-stream#options).
+For more informations you can check [`ws` options documentation](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback).
 
 _**NB:** By default if you do not provide a `server` option `fastify-websocket` will bind your websocket server instance to the scoped `fastify` instance._
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Built upon [ws](https://www.npmjs.com/package/ws).
 npm install fastify-websocket --save
 ```
 
+## Requirements
+
+* `>=nodejs-8.0.0`
+
 ## Usage
 
 There are two possible ways of using this plugin: with a **global handler** or with a **per route handler**.

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function fastifyWebsocket (fastify, opts, next) {
   function handleRouting (connection, request) {
     const response = new ServerResponse(request)
     request[kWs] = connection
+    request[kWs].socket = WebSocket.createWebSocketStream(connection, { encoding: 'utf8' }) // TODO
     router.lookup(request, response)
   }
 

--- a/index.js
+++ b/index.js
@@ -63,8 +63,7 @@ function fastifyWebsocket (fastify, opts, next) {
 
   function handleRouting (connection, request) {
     const response = new ServerResponse(request)
-    request[kWs] = connection
-    request[kWs].socket = WebSocket.createWebSocketStream(connection, { encoding: 'utf8' }) // TODO
+    request[kWs] = WebSocket.createWebSocketStream(connection)
     router.lookup(request, response)
   }
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,10 @@ function fastifyWebsocket (fastify, opts, next) {
 
   function handleRouting (connection, request) {
     const response = new ServerResponse(request)
-    request[kWs] = WebSocket.createWebSocketStream(connection)
+    request[kWs] = {
+      stream: WebSocket.createWebSocketStream(connection),
+      socket: connection
+    }
     router.lookup(request, response)
   }
 

--- a/index.js
+++ b/index.js
@@ -63,10 +63,8 @@ function fastifyWebsocket (fastify, opts, next) {
 
   function handleRouting (connection, request) {
     const response = new ServerResponse(request)
-    request[kWs] = {
-      stream: WebSocket.createWebSocketStream(connection),
-      socket: connection
-    }
+    request[kWs] = WebSocket.createWebSocketStream(connection)
+    request[kWs].socket = connection
     router.lookup(request, response)
   }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const { ServerResponse } = require('http')
 const fp = require('fastify-plugin')
-const websocket = require('websocket-stream')
+const WebSocket = require('ws')
 const findMyWay = require('find-my-way')
 
 const kWs = Symbol('ws')
@@ -22,7 +22,8 @@ function fastifyWebsocket (fastify, opts, next) {
     defaultRoute: handle
   })
 
-  const wss = websocket.createServer(options, handleRouting)
+  const wss = new WebSocket.Server(options)
+  wss.on('connection', handleRouting)
 
   fastify.decorate('websocketServer', wss)
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "fastify-plugin": "^1.5.0",
     "find-my-way": "^2.0.1",
-    "websocket-stream": "^5.5.0"
+    "ws": "^7.1.2"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "basic websocket support for fastify",
   "main": "index.js",
   "scripts": {
-    "test": "standard | snazzy && tap \"test/*.js\""
+    "lint": "standard | snazzy",
+    "unit": "tap \"test/*.js\"",
+    "test": "npm run lint && npm run unit"
   },
   "repository": {
     "type": "git",

--- a/test/base.js
+++ b/test/base.js
@@ -15,13 +15,13 @@ test('Should expose a websocket', (t) => {
   fastify.register(fastifyWebsocket, { handle })
 
   function handle (connection) {
-    connection.socket.setEncoding('utf8')
-    connection.socket.write('hello client')
-    t.tearDown(() => connection.socket.destroy())
+    connection.setEncoding('utf8')
+    connection.write('hello client')
+    t.tearDown(() => connection.destroy())
 
-    connection.socket.once('data', (chunk) => {
+    connection.once('data', (chunk) => {
       t.equal(chunk, 'hello server')
-      connection.socket.end()
+      connection.end()
     })
   }
 

--- a/test/base.js
+++ b/test/base.js
@@ -4,7 +4,7 @@ const http = require('http')
 const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyWebsocket = require('../')
-const websocket = require('websocket-stream')
+const WebSocket = require('ws')
 
 test('Should expose a websocket', (t) => {
   t.plan(3)
@@ -15,20 +15,21 @@ test('Should expose a websocket', (t) => {
   fastify.register(fastifyWebsocket, { handle })
 
   function handle (connection) {
-    connection.setEncoding('utf8')
-    connection.write('hello client')
-    t.tearDown(() => connection.destroy())
+    connection.socket.setEncoding('utf8')
+    connection.socket.write('hello client')
+    t.tearDown(() => connection.socket.destroy())
 
-    connection.once('data', (chunk) => {
+    connection.socket.once('data', (chunk) => {
       t.equal(chunk, 'hello server')
-      connection.end()
+      connection.socket.end()
     })
   }
 
   fastify.listen(0, (err) => {
     t.error(err)
 
-    const client = websocket('ws://localhost:' + fastify.server.address().port)
+    const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(() => client.destroy())
 
     client.setEncoding('utf8')
@@ -41,7 +42,7 @@ test('Should expose a websocket', (t) => {
   })
 })
 
-test('Should be able to pass custom options to websocket-stream', (t) => {
+test('Should be able to pass custom options to websocket-stream', { todo: true }, (t) => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -67,7 +68,8 @@ test('Should be able to pass custom options to websocket-stream', (t) => {
     t.error(err)
 
     const clientOptions = { headers: { 'x-custom-header': 'fastify is awesome !' } }
-    const client = websocket('ws://localhost:' + fastify.server.address().port, clientOptions)
+    const ws = new WebSocket('ws://localhost:' + fastify.server.address().port, clientOptions)
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(() => client.destroy())
 
     client.setEncoding('utf8')
@@ -80,7 +82,7 @@ test('Should be able to pass custom options to websocket-stream', (t) => {
   })
 })
 
-test('Should be able to pass a custom server option to websocket-stream', (t) => {
+test('Should be able to pass a custom server option to websocket-stream', { todo: true }, (t) => {
   t.plan(2)
 
   // We create an external server
@@ -113,7 +115,8 @@ test('Should be able to pass a custom server option to websocket-stream', (t) =>
   fastify.listen(0, (err) => {
     t.error(err)
 
-    const client = websocket('ws://localhost:' + externalServerPort)
+    const ws = new WebSocket('ws://localhost:' + externalServerPort)
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(() => client.destroy())
 
     client.setEncoding('utf8')

--- a/test/base.js
+++ b/test/base.js
@@ -3,7 +3,7 @@
 const http = require('http')
 const test = require('tap').test
 const Fastify = require('fastify')
-const fastifyWebsocket = require('../')
+const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
 
 test('Should expose a websocket', (t) => {
@@ -15,13 +15,13 @@ test('Should expose a websocket', (t) => {
   fastify.register(fastifyWebsocket, { handle })
 
   function handle (connection) {
-    connection.setEncoding('utf8')
-    connection.write('hello client')
-    t.tearDown(() => connection.destroy())
+    connection.stream.setEncoding('utf8')
+    connection.stream.write('hello client')
+    t.tearDown(() => connection.stream.destroy())
 
-    connection.once('data', (chunk) => {
+    connection.stream.once('data', (chunk) => {
       t.equal(chunk, 'hello server')
-      connection.end()
+      connection.stream.end()
     })
   }
 
@@ -42,7 +42,7 @@ test('Should expose a websocket', (t) => {
   })
 })
 
-test('Should be able to pass custom options to websocket-stream', { todo: true }, (t) => {
+test('Should be able to pass custom options to websocket-stream', (t) => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -60,8 +60,8 @@ test('Should be able to pass custom options to websocket-stream', { todo: true }
 
   // this is all that's needed to create an echo server
   function handle (connection) {
-    connection.pipe(connection)
-    t.tearDown(() => connection.destroy())
+    connection.stream.pipe(connection.stream)
+    t.tearDown(() => connection.stream.destroy())
   }
 
   fastify.listen(0, (err) => {
@@ -82,7 +82,7 @@ test('Should be able to pass custom options to websocket-stream', { todo: true }
   })
 })
 
-test('Should be able to pass a custom server option to websocket-stream', { todo: true }, (t) => {
+test('Should be able to pass a custom server option to websocket-stream', (t) => {
   t.plan(2)
 
   // We create an external server
@@ -108,8 +108,8 @@ test('Should be able to pass a custom server option to websocket-stream', { todo
 
   // this is all that's needed to create an echo server
   function handle (connection) {
-    connection.pipe(connection)
-    t.tearDown(() => connection.destroy())
+    connection.stream.pipe(connection.stream)
+    t.tearDown(() => connection.stream.destroy())
   }
 
   fastify.listen(0, (err) => {

--- a/test/base.js
+++ b/test/base.js
@@ -15,13 +15,13 @@ test('Should expose a websocket', (t) => {
   fastify.register(fastifyWebsocket, { handle })
 
   function handle (connection) {
-    connection.stream.setEncoding('utf8')
-    connection.stream.write('hello client')
-    t.tearDown(() => connection.stream.destroy())
+    connection.setEncoding('utf8')
+    connection.write('hello client')
+    t.tearDown(() => connection.destroy())
 
-    connection.stream.once('data', (chunk) => {
+    connection.once('data', (chunk) => {
       t.equal(chunk, 'hello server')
-      connection.stream.end()
+      connection.end()
     })
   }
 
@@ -60,8 +60,8 @@ test('Should be able to pass custom options to websocket-stream', (t) => {
 
   // this is all that's needed to create an echo server
   function handle (connection) {
-    connection.stream.pipe(connection.stream)
-    t.tearDown(() => connection.stream.destroy())
+    connection.pipe(connection)
+    t.tearDown(() => connection.destroy())
   }
 
   fastify.listen(0, (err) => {
@@ -108,8 +108,8 @@ test('Should be able to pass a custom server option to websocket-stream', (t) =>
 
   // this is all that's needed to create an echo server
   function handle (connection) {
-    connection.stream.pipe(connection.stream)
-    t.tearDown(() => connection.stream.destroy())
+    connection.pipe(connection)
+    t.tearDown(() => connection.destroy())
   }
 
   fastify.listen(0, (err) => {

--- a/test/router.js
+++ b/test/router.js
@@ -116,11 +116,11 @@ test(`Should close on unregistered path`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/echo', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       try {
-        connection.socket.send(message)
+        connection.send(message)
       } catch (err) {
-        connection.socket.send(err.message)
+        connection.send(err.message)
       }
     })
 
@@ -132,7 +132,7 @@ test(`Should close on unregistered path`, t => {
     const client = websocket('ws://localhost:' + (fastify.server.address()).port)
     t.tearDown(client.destroy.bind(client))
 
-    client.socket.on('close', () => {
+    client.on('close', () => {
       t.pass()
     })
   })
@@ -147,11 +147,11 @@ test(`Should throw on wrong HTTP method`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.post('/echo', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       try {
-        connection.socket.send(message)
+        connection.send(message)
       } catch (err) {
-        connection.socket.send(err.message)
+        connection.send(err.message)
       }
     })
     t.tearDown(connection.destroy.bind(connection))
@@ -194,11 +194,11 @@ test(`Should open on registered path`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/echo', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       try {
-        connection.socket.send(message)
+        connection.send(message)
       } catch (err) {
-        connection.socket.send(err.message)
+        connection.send(err.message)
       }
     })
 
@@ -210,7 +210,7 @@ test(`Should open on registered path`, t => {
     const client = websocket('ws://localhost:' + (fastify.server.address()).port + '/echo/')
     t.tearDown(client.destroy.bind(client))
 
-    client.socket.on('open', () => {
+    client.on('open', () => {
       t.pass()
       client.end()
     })
@@ -226,12 +226,12 @@ test(`Should send message and close`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       t.equal(message, 'hi from client')
-      connection.socket.send('hi from server')
+      connection.send('hi from server')
     })
 
-    connection.socket.on('close', () => {
+    connection.on('close', () => {
       t.pass()
     })
 
@@ -242,16 +242,16 @@ test(`Should send message and close`, t => {
     t.error(err)
     const client = websocket('ws://localhost:' + (fastify.server.address()).port + '/')
     t.tearDown(client.destroy.bind(client))
-    client.socket.on('message', message => {
+    client.on('message', message => {
       t.equal(message, 'hi from server')
     })
 
-    client.socket.on('open', () => {
-      client.socket.send('hi from client')
+    client.on('open', () => {
+      client.send('hi from client')
       client.end()
     })
 
-    client.socket.on('close', () => {
+    client.on('close', () => {
       t.pass()
     })
   })
@@ -265,12 +265,12 @@ test(`Should return 404 on http request`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       t.equal(message, 'hi from client')
-      connection.socket.send('hi from server')
+      connection.send('hi from server')
     })
 
-    connection.socket.on('close', () => {
+    connection.on('close', () => {
       t.pass()
     })
 

--- a/test/router.js
+++ b/test/router.js
@@ -16,13 +16,13 @@ test('Should expose a websocket on prefixed route', t => {
   fastify.register(
     function (instance, opts, next) {
       instance.get('/echo', { websocket: true }, (conn, req) => {
-        conn.stream.setEncoding('utf8')
-        conn.stream.write('hello client')
-        t.tearDown(conn.stream.destroy.bind(conn.stream))
+        conn.setEncoding('utf8')
+        conn.write('hello client')
+        t.tearDown(conn.destroy.bind(conn))
 
-        conn.stream.once('data', chunk => {
+        conn.once('data', chunk => {
           t.equal(chunk, 'hello server')
-          conn.stream.end()
+          conn.end()
         })
       })
       next()
@@ -62,13 +62,13 @@ test('Should expose websocket and http route', t => {
           reply.send({ hello: 'world' })
         },
         wsHandler: (conn, req) => {
-          conn.stream.setEncoding('utf8')
-          conn.stream.write('hello client')
-          t.tearDown(conn.stream.destroy.bind(conn.stream))
+          conn.setEncoding('utf8')
+          conn.write('hello client')
+          t.tearDown(conn.destroy.bind(conn))
 
-          conn.stream.once('data', chunk => {
+          conn.once('data', chunk => {
             t.equal(chunk, 'hello server')
-            conn.stream.end()
+            conn.end()
           })
         }
       })
@@ -202,7 +202,7 @@ test(`Should open on registered path`, t => {
       }
     })
 
-    t.tearDown(connection.stream.destroy.bind(connection.stream))
+    t.tearDown(connection.destroy.bind(connection))
   })
 
   fastify.listen(0, err => {
@@ -236,7 +236,7 @@ test(`Should send message and close`, t => {
       t.pass()
     })
 
-    t.tearDown(connection.stream.destroy.bind(connection.stream))
+    t.tearDown(connection.destroy.bind(connection))
   })
 
   fastify.listen(0, err => {
@@ -298,13 +298,13 @@ test('Should pass route params to handlers', t => {
   fastify.register(fastifyWebsocket)
   fastify.get('/ws', { websocket: true }, (conn, req, params) => {
     t.equal(Object.keys(params).length, 0, 'params are empty')
-    conn.stream.write('empty')
-    conn.stream.end()
+    conn.write('empty')
+    conn.end()
   })
   fastify.get('/ws/:id', { websocket: true }, (conn, req, params) => {
     t.equal(params.id, 'foo', 'params are correct')
-    conn.stream.write(params.id)
-    conn.stream.end()
+    conn.write(params.id)
+    conn.end()
   })
 
   fastify.listen(0, err => {

--- a/test/router.js
+++ b/test/router.js
@@ -16,13 +16,13 @@ test('Should expose a websocket on prefixed route', t => {
   fastify.register(
     function (instance, opts, next) {
       instance.get('/echo', { websocket: true }, (conn, req) => {
-        conn.socket.setEncoding('utf8')
-        conn.socket.write('hello client')
-        t.tearDown(conn.socket.destroy.bind(conn.socket))
+        conn.setEncoding('utf8')
+        conn.write('hello client')
+        t.tearDown(conn.destroy.bind(conn))
 
-        conn.socket.once('data', chunk => {
+        conn.once('data', chunk => {
           t.equal(chunk, 'hello server')
-          conn.socket.end()
+          conn.end()
         })
       })
       next()
@@ -62,13 +62,13 @@ test('Should expose websocket and http route', t => {
           reply.send({ hello: 'world' })
         },
         wsHandler: (conn, req) => {
-          conn.socket.setEncoding('utf8')
-          conn.socket.write('hello client')
-          t.tearDown(conn.socket.destroy.bind(conn.socket))
+          conn.setEncoding('utf8')
+          conn.write('hello client')
+          t.tearDown(conn.destroy.bind(conn))
 
-          conn.socket.once('data', chunk => {
+          conn.once('data', chunk => {
             t.equal(chunk, 'hello server')
-            conn.socket.end()
+            conn.end()
           })
         }
       })
@@ -116,11 +116,11 @@ test(`Should close on unregistered path`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/echo', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       try {
-        connection.socket.send(message)
+        connection.send(message)
       } catch (err) {
-        connection.socket.send(err.message)
+        connection.send(err.message)
       }
     })
 
@@ -148,11 +148,11 @@ test(`Should throw on wrong HTTP method`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.post('/echo', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       try {
-        connection.socket.send(message)
+        connection.send(message)
       } catch (err) {
-        connection.socket.send(err.message)
+        connection.send(err.message)
       }
     })
     t.tearDown(connection.destroy.bind(connection))
@@ -195,15 +195,15 @@ test(`Should open on registered path`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/echo', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       try {
-        connection.socket.send(message)
+        connection.send(message)
       } catch (err) {
-        connection.socket.send(err.message)
+        connection.send(err.message)
       }
     })
 
-    t.tearDown(connection.socket.destroy.bind(connection.socket))
+    t.tearDown(connection.destroy.bind(connection))
   })
 
   fastify.listen(0, err => {
@@ -228,16 +228,16 @@ test(`Should send message and close`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       t.equal(message, 'hi from client')
-      connection.socket.send('hi from server')
+      connection.send('hi from server')
     })
 
-    connection.socket.on('close', () => {
+    connection.on('close', () => {
       t.pass()
     })
 
-    t.tearDown(connection.socket.destroy.bind(connection.socket))
+    t.tearDown(connection.destroy.bind(connection))
   })
 
   fastify.listen(0, err => {
@@ -268,12 +268,12 @@ test(`Should return 404 on http request`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (connection, req) => {
-    connection.socket.on('message', message => {
+    connection.on('message', message => {
       t.equal(message, 'hi from client')
-      connection.socket.send('hi from server')
+      connection.send('hi from server')
     })
 
-    connection.socket.on('close', () => {
+    connection.on('close', () => {
       t.pass()
     })
 
@@ -298,13 +298,13 @@ test('Should pass route params to handlers', t => {
   fastify.register(fastifyWebsocket)
   fastify.get('/ws', { websocket: true }, (conn, req, params) => {
     t.equal(Object.keys(params).length, 0, 'params are empty')
-    conn.socket.write('empty')
-    conn.socket.end()
+    conn.write('empty')
+    conn.end()
   })
   fastify.get('/ws/:id', { websocket: true }, (conn, req, params) => {
     t.equal(params.id, 'foo', 'params are correct')
-    conn.socket.write(params.id)
-    conn.socket.end()
+    conn.write(params.id)
+    conn.end()
   })
 
   fastify.listen(0, err => {

--- a/test/router.js
+++ b/test/router.js
@@ -116,11 +116,11 @@ test(`Should close on unregistered path`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/echo', { websocket: true }, (connection, req) => {
-    connection.on('message', message => {
+    connection.socket.on('message', message => {
       try {
-        connection.send(message)
+        connection.socket.send(message)
       } catch (err) {
-        connection.send(err.message)
+        connection.socket.send(err.message)
       }
     })
 
@@ -133,7 +133,7 @@ test(`Should close on unregistered path`, t => {
     const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(client.destroy.bind(client))
 
-    client.on('close', () => {
+    client.socket.on('close', () => {
       t.pass()
     })
   })
@@ -148,11 +148,11 @@ test(`Should throw on wrong HTTP method`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.post('/echo', { websocket: true }, (connection, req) => {
-    connection.on('message', message => {
+    connection.socket.on('message', message => {
       try {
-        connection.send(message)
+        connection.socket.send(message)
       } catch (err) {
-        connection.send(err.message)
+        connection.socket.send(err.message)
       }
     })
     t.tearDown(connection.destroy.bind(connection))
@@ -195,11 +195,11 @@ test(`Should open on registered path`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/echo', { websocket: true }, (connection, req) => {
-    connection.on('message', message => {
+    connection.socket.on('message', message => {
       try {
-        connection.send(message)
+        connection.socket.send(message)
       } catch (err) {
-        connection.send(err.message)
+        connection.socket.send(err.message)
       }
     })
 
@@ -212,7 +212,7 @@ test(`Should open on registered path`, t => {
     const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(client.destroy.bind(client))
 
-    client.on('open', () => {
+    client.socket.on('open', () => {
       t.pass()
       client.end()
     })
@@ -228,12 +228,12 @@ test(`Should send message and close`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (connection, req) => {
-    connection.on('message', message => {
+    connection.socket.on('message', message => {
       t.equal(message, 'hi from client')
-      connection.send('hi from server')
+      connection.socket.send('hi from server')
     })
 
-    connection.on('close', () => {
+    connection.socket.on('close', () => {
       t.pass()
     })
 
@@ -245,16 +245,16 @@ test(`Should send message and close`, t => {
     const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/')
     const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(client.destroy.bind(client))
-    client.on('message', message => {
+    client.socket.on('message', message => {
       t.equal(message, 'hi from server')
     })
 
-    client.on('open', () => {
-      client.send('hi from client')
+    client.socket.on('open', () => {
+      client.socket.send('hi from client')
       client.end()
     })
 
-    client.on('close', () => {
+    client.socket.on('close', () => {
       t.pass()
     })
   })
@@ -268,12 +268,12 @@ test(`Should return 404 on http request`, t => {
   fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (connection, req) => {
-    connection.on('message', message => {
+    connection.socket.on('message', message => {
       t.equal(message, 'hi from client')
-      connection.send('hi from server')
+      connection.socket.send('hi from server')
     })
 
-    connection.on('close', () => {
+    connection.socket.on('close', () => {
       t.pass()
     })
 


### PR DESCRIPTION
Continue of PR #34 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Fixed tests.

This potentially introduces breaking change. As `ws`'s `createWebSocketStream` returns node.js stream without any additional props that were in `websocket-stream` I've replaced old `connection` with object that contains two properties: `stream` - websocket stream and `socket` which refers to websocket instance. Actually it's possible just to add socket to node stream object that `createWebSocketStream` returns, but I'd rather prefer to keep it as is.

@mcollina, @Eomm please review and tell if you're okay with such change or not. And after that I continue with updating docs and probably rewriting `verifyClient`, cause it's deprecated and may be removed soon.

PS: Current ws version doesn't support node 6, and I think that this plugins should also drop it's support.