### PR TITLE
Send a close to all websocket connections when server closes

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,18 @@ function fastifyWebsocket (fastify, opts, next) {
 
   fastify.addHook('onClose', close)
 
+  // Fastify is missing a pre-close event, or the ability to
+  // add a hook before the server.close call. We need to resort
+  // to monkeypatching for now.
+  const oldClose = fastify.server.close
+  fastify.server.close = function (cb) {
+    const server = fastify.websocketServer
+    for (const client of server.clients) {
+      client.close()
+    }
+    oldClose.call(this, cb)
+  }
+
   function handleRouting (connection, request) {
     const response = new ServerResponse(request)
     request[kWs] = WebSocket.createWebSocketStream(connection)
@@ -72,7 +84,8 @@ function fastifyWebsocket (fastify, opts, next) {
 }
 
 function close (fastify, done) {
-  fastify.websocketServer.close(done)
+  const server = fastify.websocketServer
+  server.close(done)
 }
 
 module.exports = fp(fastifyWebsocket, {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

As noted by @franky47 in #45, the http server close callback does not fire until all connections are closed. This works extremely well for http requests, because it allows to wait until everything is done. It does not work well for websockets, because we need to call a method in each of them `close()`, hence I monkeypatch the server.close method.

I think we should send a PR to fastify to add the ability to handle this specific case.

This is a draft PR because the behavior should likely be customizable, i.e. the `client.close()` accepts a code and a message.

Fixes #45.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
