### PR TITLE
fix(types): allow websocket server options without specifying global …

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ declare module 'fastify' {
   > = (
     this: FastifyInstance<Server, HttpRequest, HttpResponse>,
     connection: websocketPlugin.SocketStream,
-    request: FastifyRequest<HttpRequest, Query, Params, Headers, Body>,
+    request: HttpRequest,
     params?: { [key: string]: any }
   ) => void | Promise<any>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ declare namespace websocketPlugin {
   }
 
   export interface PluginOptions {
-    handle: (connection: SocketStream) => void;
+    handle?: (connection: SocketStream) => void;
     options: WebSocket.ServerOptions;
   }
 }

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,18 +1,30 @@
 const wsPlugin = require('../..');
 const fastify = require('fastify');
+import { IncomingMessage } from "http";
 import { SocketStream } from '../..';
-import { WebsocketHandler, FastifyRequest, FastifyInstance } from 'fastify';
+import { WebsocketHandler, FastifyInstance } from 'fastify';
 import { expectType } from 'tsd';
 
 const app: FastifyInstance = fastify();
 app.register(wsPlugin);
 
+app.register(wsPlugin, {
+  handle: () => null,
+});
+
+app.register(wsPlugin, {
+  options: {
+    url: "/ws"
+  }
+});
+
 const handler: WebsocketHandler = (
-  connection: SocketStream,
-  req: FastifyRequest,
+  connection,
+  req,
   params
 ) => {
   expectType<SocketStream>(connection);
+  expectType<IncomingMessage>(req);
   expectType<{ [key: string]: any } | undefined>(params);
 };
 


### PR DESCRIPTION
I am in a situation where I need to parse query params out of the url of a connected client and do some authentication checks. Thats currently impossible with typings provided since when I specify verifyClient as an option for the web socket server I have to specify a handler as well. I don't need a global handler though as I am handling the web socket connections on a route to have access to the request url. This PR makes handle optional to fix this issue. I guess I could also just give it a handler the does nothing as the handler will not be used by "per route web socket handlers" anyway.

Thoughts?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
