### PR TITLE
feature: Added an option to not wrap the websocket in a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ fastify.listen(3000, err => {
 })
 ```
 
+You also have the option not wrap the websocket in a Node Stream. In that case the handler will accept a plain websocket as a parameter.
+
+```js
+const fastify = require('fastify')()
+
+function handle (ws) { // this is a plain Websocket instead of a Connection Stream
+  ws.send('hello from the client') // we use Websocket methods here
+}
+
+fastify.register(require('fastify-websocket'), {
+  handle,
+  stream: false // flag to pass the Websocket parameter in the provided handler function
+})
+``` 
+
 ### Per route handler
 
 After registering this plugin, you can choose on which routes the WS server will respond. This could be achieved by adding `websocket: true` property to `routeOptions` on a fastify's `.get` route. In this case two arguments will be passed to the handler: socket connection and the original `http.IncomingMessage` (instead of the usual fastify's request and reply objects).

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,8 +82,9 @@ declare namespace websocketPlugin {
   }
 
   export interface PluginOptions {
-    handle: (connection: SocketStream) => void;
+    handle: (connection: SocketStream | WebSocket) => void;
     options: WebSocket.ServerOptions;
+    stream?: boolean;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ function fastifyWebsocket (fastify, opts, next) {
   if (opts.handle && typeof opts.handle !== 'function') {
     return next(new Error('invalid handle function'))
   }
-  const isStream = typeof opts.stream === 'undefined'
-    ? true : !!opts.stream
+  const isStream = typeof opts.stream === 'boolean' ? opts.stream : true
   const handle = opts.handle
     ? (req, res) => opts.handle(req[kWs], req)
     : (req, res) => { isStream ? req[kWs].socket.close() : req[kWs].close() }

--- a/test/types/global-handler.test-d.ts
+++ b/test/types/global-handler.test-d.ts
@@ -1,0 +1,19 @@
+import websocketPlugin = require('../../index');
+const fastify = require('fastify');
+import { FastifyInstance } from 'fastify';
+import { SocketStream } from '../../index';
+import * as WebSocket from 'ws';
+import { expectType } from 'tsd';
+
+const app: FastifyInstance = fastify();
+function handle (ws: WebSocket | SocketStream) {
+    expectType<SocketStream | WebSocket>(ws)
+}
+
+app.register(websocketPlugin, {
+    handle,
+    options: {
+        path: '/ws'
+    },
+    stream: false,
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Added an option to not wrap the websocket in a stream. Fixes #40

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ x] run `npm run test` and `npm run benchmark`
- [x ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
