### PR TITLE
Fix PluginOptions incorrect typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,8 +84,8 @@ declare namespace websocketPlugin {
   }
 
   export interface PluginOptions {
-    handle: (connection: SocketStream) => void;
-    options: WebSocket.ServerOptions;
+    handle?: (connection: SocketStream) => void;
+    options?: WebSocket.ServerOptions;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="node" />
-import * as fastify from 'fastify';
 import { IncomingMessage, ServerResponse, Server } from 'http';
 import { Plugin } from 'fastify';
 import * as WebSocket from 'ws';
@@ -40,7 +39,7 @@ declare module 'fastify' {
       >,
       handler?: WebsocketHandler<HttpRequest, HttpResponse>
     ): FastifyInstance<HttpServer, HttpRequest, HttpResponse>;
-    
+
     websocketServer: WebSocket.Server;
   }
 

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -5,9 +5,6 @@ import { WebsocketHandler, FastifyRequest, FastifyInstance } from 'fastify';
 import { expectType } from 'tsd';
 import { Server } from 'ws';
 
-const app: FastifyInstance = fastify();
-app.register(wsPlugin);
-
 const handler: WebsocketHandler = (
   connection: SocketStream,
   req: FastifyRequest,
@@ -17,5 +14,11 @@ const handler: WebsocketHandler = (
   expectType<Server>(app.websocketServer);
   expectType<{ [key: string]: any } | undefined>(params);
 };
+
+const app: FastifyInstance = fastify();
+app.register(wsPlugin);
+app.register(wsPlugin, {});
+app.register(wsPlugin, { handler });
+app.register(wsPlugin, { options: { perMessageDeflate: true } });
 
 app.get('/', { websocket: true }, handler);


### PR DESCRIPTION
Hello 👋 

First of all, thanks @mcollina, @delvedor & all contributors for the awesome `fastify` ecosystem. I had just recently dived into it & I'm very impressed.

Moving on to the issue on hand, I found out that the TS typing provided for `PluginOptions` (used in `fastify.register(ws, opts \*here*\)` is incorrect: **the typings requires both `handler` and `options` to be passed in**. I looked into the docs & code to verify that it has defaults specified.

I fixed this in this PR, and had added tests to cover this use-case. Additionally, I did minor clean-up on the declaration file.

I think this addresses #47 too.

#### Checklist

- [X] run `npm run test` and `npm run benchmark` (I couldn't find `npm run bench` nor `npm run benchmark`, should the PR template be updated?)
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
