### PR TITLE
fixed Method 'GET' already declared for route Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,31 +35,32 @@ function fastifyWebsocket (fastify, opts, next) {
         throw new Error('websocket handler can only be declared in GET method')
       }
 
-      if (routeOptions.path !== routeOptions.prefix) {
-        let wsHandler = routeOptions.wsHandler
-        let handler = routeOptions.handler
-
-        if (routeOptions.websocket) {
-          wsHandler = routeOptions.handler
-          handler = function (request, reply) {
-            reply.code(404).send()
-          }
-        }
-
-        if (typeof wsHandler !== 'function') {
-          throw new Error('invalid wsHandler function')
-        }
-
-        router.on('GET', routeOptions.path, (req, _, params) => {
-          const result = wsHandler(req[kWs], req, params)
-
-          if (result && typeof result.catch === 'function') {
-            result.catch(err => req[kWs].destroy(err))
-          }
-        })
-
-        routeOptions.handler = handler
+      if (routeOptions.path === routeOptions.prefix) {
+        return
       }
+      let wsHandler = routeOptions.wsHandler
+      let handler = routeOptions.handler
+
+      if (routeOptions.websocket) {
+        wsHandler = routeOptions.handler
+        handler = function (request, reply) {
+          reply.code(404).send()
+        }
+      }
+
+      if (typeof wsHandler !== 'function') {
+        throw new Error('invalid wsHandler function')
+      }
+
+      router.on('GET', routeOptions.path, (req, _, params) => {
+        const result = wsHandler(req[kWs], req, params)
+
+        if (result && typeof result.catch === 'function') {
+          result.catch(err => req[kWs].destroy(err))
+        }
+      })
+
+      routeOptions.handler = handler
     }
   })
 


### PR DESCRIPTION
I fixed the error addressed on this issue [61](https://github.com/fastify/fastify-websocket/issues/61)

> Method 'GET' already declared for route '/<prefix>'
caused by setting empty get path route `fastify.get('/', <function>)` after registering with prefix.
and websocket will register two paths `<prefix>` and `<prefix/>` and two handler. which causes this error.

p.s. This is my first PR ever! so if something is not right, I would be thankful if you could guide me :)
#### Checklist

- [✓ ] run `npm run test` and `npm run benchmark`
- [ ✓] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ✓] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
