### PR TITLE
Update TypeScript types to match actual request object passed to handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare module 'fastify' {
   export type WebsocketHandler = (
     this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
     connection: SocketStream,
-    request: FastifyRequest,
+    request: IncomingMessage,
     params?: { [key: string]: any }
   ) => void | Promise<any>;
 }

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -6,18 +6,18 @@ import { Server } from 'ws';
 
 const handler: WebsocketHandler = (
   connection: SocketStream,
-  req: FastifyRequest,
+  req: IncomingMessage,
   params
 ) => {
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
-  expectType<FastifyRequest<HttpServer, IncomingMessage, RequestGenericInterface>>(req)
+  expectType<IncomingMessage>(req)
   expectType<{ [key: string]: any } | undefined>(params);
 };
 
 const handle = (connection: SocketStream): void => {
   expectType<SocketStream>(connection)
-} 
+}
 
 const app: FastifyInstance = fastify();
 app.register(wsPlugin);


### PR DESCRIPTION
In the README it states (and in my experience also) the handler doesn't get a full on `FastifyRequest` object. It gets an `http.IncomingMessage` instead! This makes the TypeScript types reflect that.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
