### PR TITLE
Ensure websocket handler types are only applied to websocket handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module 'fastify' {
   > {
     <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault>(
       path: string,
-      opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>,
+      opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> & { websocket: true }, // this creates an overload that only applies these different types if the handler is for websockets
       handler?: WebsocketHandler
     ): FastifyInstance<RawServer, RawRequest, RawReply>;
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
     "@types/ws": "^7.2.4",
-    "fastify": "^3.0.0",
+    "fastify": "^3.0.2",
     "pre-commit": "^1.2.2",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",


### PR DESCRIPTION
This corrects an issue introduced in #64 where upon adding `fastify-websocket` to a project all route handlers were (accidentally) assumed to be websocket handlers getting the different (and decidedly less useful) types. My bad! This corrects the issue by using a type-land overload of the RouteShorthand function definition to change the type of the handler only if the handler is in fact `{ websocket: true }`.

Also adds tests, `tsd` is handy!

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
