### PR TITLE
Added test that covers error inside async handler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "lint": "standard | snazzy",
-    "unit": "tap \"test/*.js\"",
+    "unit": "tap --100 \"test/*.js\"",
     "test:js": "npm run lint && npm run unit",
     "test:ts": "tsd",
     "test": "npm run lint && npm run test:js && npm run test:ts"

--- a/test/router.js
+++ b/test/router.js
@@ -460,3 +460,31 @@ test('should call `destroy` when exception is thrown inside async handler', t =>
     t.tearDown(client.destroy.bind(client))
   })
 })
+
+test('register a non websocket route', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+  fastify.get('/ws', function handler (req, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    get('http://localhost:' + (fastify.server.address()).port + '/ws', function (response) {
+      let data = ''
+
+      response.on('data', (chunk) => {
+        data += chunk
+      })
+
+      response.on('end', () => {
+        t.equal(data, '{"hello":"world"}')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
closes #69 
```
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |      100 |      100 |      100 |                   |
 index.js |      100 |      100 |      100 |      100 |                   |
----------|----------|----------|----------|----------|-------------------|
```



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
