### PR TITLE
fix: Resume connection before continuing. [#77]

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,11 @@ function fastifyWebsocket (fastify, opts, next) {
   }
 
   function wsHandle (handle, req, res) {
-    req[kWs].resume()
+    req[kWs].socket.on('newListener', event => {
+      if (event === 'message') {
+        req[kWs].resume()
+      }
+    })
 
     return handle.call(fastify, req[kWs], res)
   }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,11 @@ function fastifyWebsocket (fastify, opts, next) {
     return next(new Error('invalid handle function'))
   }
   const handle = opts.handle
-    ? (req, res) => opts.handle.call(fastify, req[kWs], req)
+    ? (req, res) => {
+      req[kWs].resume()
+
+      return opts.handle.call(fastify, req[kWs], req)
+    }
     : (req, res) => {
       req[kWs].socket.close()
     }


### PR DESCRIPTION
This fixes #77 by resuming the connection before calling the handler.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
