### PR TITLE
Bump find-my-way to 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "find-my-way": "^3.0.4",
+    "find-my-way": "^3.0.5",
     "ws": "^7.3.1"
   }
 }


### PR DESCRIPTION
Bumps `find-my-way` dependency to a minimum version of `3.0.5` in order to resolve this security alert:
https://github.com/advisories/GHSA-jgrh-5m3h-9c5f

```
Suites:   2 passed, 2 of 2 completed
Asserts:  65 passed, of 65
```

#### Checklist

- [✅] run `npm run test` and `npm run benchmark`
- [✅] tests and/or benchmarks are included
- [✅] documentation is changed or added
- [✅] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
