### PR TITLE
Adding support for hooks/decorators by using FastifyRequest for websocket handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ const fastify = require('fastify')()
 
 fastify.register(require('fastify-websocket'), {
   handle,
-  errorHandler: function (conn /* SocketStream */, error) {
+  errorHandler: function (error, conn /* SocketStream */) {
     // Do stuff
     // destroy/close connection
     conn.destroy(error)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You can optionally provide a custom errorHandler that will be used to handle any
 const fastify = require('fastify')()
 
 fastify.register(require('fastify-websocket'), {
-  errorHandler: function (error, conn /* SocketStream */) {
+  errorHandler: function (error, conn /* SocketStream */, req /* FastifyRequest */, reply /* FastifyReply */) {
     // Do stuff
     // destroy/close connection
     conn.destroy(error)

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fastify.listen(3000, err => {
 
 ## Options :
 
-`fastify-websocket` accept the same options as [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :
+`fastify-websocket` accept these options for [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :
 
 - `objectMode` - Send each chunk on its own, and do not try to pack them in a single websocket frame.
 - `host` - The hostname where to bind the server.
@@ -202,7 +202,6 @@ fastify.listen(3000, err => {
 - `server` - A pre-created Node.js HTTP/S server.
 - `verifyClient` - A function which can be used to validate incoming connections.
 - `handleProtocols` - A function which can be used to handle the WebSocket subprotocols.
-- `path` - Accept only connections matching this path.
 - `noServer` - Enable no server mode.
 - `clientTracking` - Specifies whether or not to track clients.
 - `perMessageDeflate` - Enable/disable permessage-deflate.
@@ -211,6 +210,8 @@ fastify.listen(3000, err => {
 For more informations you can check [`ws` options documentation](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback).
 
 _**NB:** By default if you do not provide a `server` option `fastify-websocket` will bind your websocket server instance to the scoped `fastify` instance._
+
+_**NB:** `path` option from `ws` shouldn't be provided (and will be ignored) since the routing is handled by fastify itself_
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ fastify.register(require('fastify-websocket'), {
   },
   options: {
     maxPayload: 1048576, // we set the maximum allowed messages size to 1 MiB (1024 bytes * 1024 bytes)
-    path: '/fastify', // we accept only connections matching this path e.g.: ws://localhost:3000/fastify
     verifyClient: function (info, next) {
       if (info.req.headers['x-fastify-header'] !== 'fastify is awesome !') {
         return next(false) // the connection is not allowed

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For more informations you can check [`ws` options documentation](https://github.
 
 _**NB:** By default if you do not provide a `server` option `fastify-websocket` will bind your websocket server instance to the scoped `fastify` instance._
 
-_**NB:** `path` option from `ws` shouldn't be provided (and will be ignored) since the routing is handled by fastify itself_
+_**NB:** `path` option from `ws` shouldn't be provided since the routing is handled by fastify itself_
 
 ## Acknowledgements
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,6 @@ export interface SocketStream extends Duplex {
 }
 
 export interface WebsocketPluginOptions {
-  handle?: (this: FastifyInstance, connection: SocketStream, req: IncomingMessage) => void;
   errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream) => void;
   options?: WebSocket.ServerOptions;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export interface SocketStream extends Duplex {
 }
 
 export interface WebsocketPluginOptions {
-  handle?: (this: FastifyInstance, connection: SocketStream) => void;
+  handle?: (this: FastifyInstance, connection: SocketStream, req: IncomingMessage) => void;
   options?: WebSocket.ServerOptions;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ export interface SocketStream extends Duplex {
 
 export interface WebsocketPluginOptions {
   handle?: (this: FastifyInstance, connection: SocketStream, req: IncomingMessage) => void;
+  errorHandler?: (this: FastifyInstance, connection: SocketStream, error: Error) => void;
   options?: WebSocket.ServerOptions;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,9 @@ declare module 'fastify' {
 
 declare const websocketPlugin: FastifyPluginCallback<WebsocketPluginOptions>;
 
+interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, 'path'> {}
+
+
 export type WebsocketHandler = (
   this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   connection: SocketStream,
@@ -50,7 +53,7 @@ export interface SocketStream extends Duplex {
 
 export interface WebsocketPluginOptions {
   errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply) => void;
-  options?: WebSocket.ServerOptions;
+  options?: WebSocketServerOptions;
 }
 
 export interface RouteOptions extends fastify.RouteOptions, WebsocketRouteOptions {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 import { IncomingMessage, ServerResponse, Server } from 'http';
-import { FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance } from 'fastify';
+import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance } from 'fastify';
 import * as fastify from 'fastify';
 import * as WebSocket from 'ws';
 import { Duplex } from 'stream';
@@ -40,8 +40,7 @@ declare const websocketPlugin: FastifyPluginCallback<WebsocketPluginOptions>;
 export type WebsocketHandler = (
   this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   connection: SocketStream,
-  request: IncomingMessage,
-  params?: { [key: string]: any }
+  request: FastifyRequest,
 ) => void | Promise<any>;
 
 export interface SocketStream extends Duplex {

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ export interface SocketStream extends Duplex {
 
 export interface WebsocketPluginOptions {
   handle?: (this: FastifyInstance, connection: SocketStream, req: IncomingMessage) => void;
-  errorHandler?: (this: FastifyInstance, connection: SocketStream, error: Error) => void;
+  errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream) => void;
   options?: WebSocket.ServerOptions;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault,
 import * as fastify from 'fastify';
 import * as WebSocket from 'ws';
 import { Duplex } from 'stream';
+import { FastifyReply } from 'fastify/types/reply';
 
 interface WebsocketRouteOptions {
   wsHandler?: WebsocketHandler
@@ -48,7 +49,7 @@ export interface SocketStream extends Duplex {
 }
 
 export interface WebsocketPluginOptions {
-  errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream) => void;
+  errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply) => void;
   options?: WebSocket.ServerOptions;
 }
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ function fastifyWebsocket (fastify, opts, next) {
   }
 
   function noHandle (conn, req) {
+    this.log.info({ path: req.url }, 'closed incoming websocket connection')
     req[kWs].socket.close()
   }
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ function fastifyWebsocket (fastify, opts, next) {
   }
 
   const options = Object.assign({}, opts.options)
+  if (options.path) {
+    fastify.log.warn('ws server path option shouldn\'t be provided, use a route instead')
+    delete options.path
+  }
   if (!options.server && !options.noServer) {
     options.server = fastify.server
   }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ function fastifyWebsocket (fastify, opts, next) {
   const options = Object.assign({}, opts.options)
   if (options.path) {
     fastify.log.warn('ws server path option shouldn\'t be provided, use a route instead')
-    delete options.path
   }
   if (!options.server && !options.noServer) {
     options.server = fastify.server

--- a/index.js
+++ b/index.js
@@ -82,10 +82,8 @@ function fastifyWebsocket (fastify, opts, next) {
     req[kWs].socket.close()
   }
 
-  // We monkeypatch the default route in order to
-  // support the websocket global handler
-  const oldDefaultRoute = fastify.defaultRoute
-  fastify.defaultRoute = function (req, res) {
+  const oldDefaultRoute = fastify.getDefaultRoute()
+  fastify.setDefaultRoute(function (req, res) {
     if (req[kWs]) {
       const result = handle.call(fastify, req[kWs], req)
       if (result && typeof result.catch === 'function') {
@@ -94,7 +92,7 @@ function fastifyWebsocket (fastify, opts, next) {
     } else {
       return oldDefaultRoute(req, res)
     }
-  }
+  })
 
   function handleRouting (connection, request) {
     const response = new ServerResponse(request)

--- a/index.js
+++ b/index.js
@@ -142,6 +142,6 @@ function close (fastify, done) {
 }
 
 module.exports = fp(fastifyWebsocket, {
-  fastify: '>= 3.10.1',
+  fastify: '>= 3.11.0',
   name: 'fastify-websocket'
 })

--- a/index.js
+++ b/index.js
@@ -50,15 +50,15 @@ function fastifyWebsocket (fastify, opts, next) {
         throw new Error('invalid wsHandler function')
       }
 
-      routeOptions.handler = (req, reply) => {
-        if (req.raw[kWs]) {
+      routeOptions.handler = (request, reply) => {
+        if (request.raw[kWs]) {
           reply.hijack()
-          const result = wsHandler.call(fastify, req.raw[kWs], req, req.params)
+          const result = wsHandler.call(fastify, request.raw[kWs], request)
           if (result && typeof result.catch === 'function') {
-            result.catch(err => req.raw[kWs].destroy(err))
+            result.catch(err => request.raw[kWs].destroy(err))
           }
         } else {
-          return handler.call(fastify, req, reply, req.params)
+          return handler.call(fastify, request, reply)
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ function fastifyWebsocket (fastify, opts, next) {
     // library from emitting the error and causing an uncaughtException
     // Reference: https://github.com/websockets/ws/blob/master/lib/stream.js#L35
     conn.on('error', _ => {})
+    fastify.log.error(error)
     conn.destroy(error)
   }
 

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ function fastifyWebsocket (fastify, opts, next) {
     // library from emitting the error and causing an uncaughtException
     // Reference: https://github.com/websockets/ws/blob/master/lib/stream.js#L35
     conn.on('error', _ => {})
+    // TODO: Use req.log instead in the future.
     fastify.log.error(error)
     conn.destroy(error)
   }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function fastifyWebsocket (fastify, opts, next) {
       // Hijack reply to prevent fastify from sending the error after onError hooks are done running
       reply.hijack()
       // Handle the error
-      errorHandler.call(this, request.raw[kWs], error)
+      errorHandler.call(this, error, request.raw[kWs])
     }
     done()
   })
@@ -84,7 +84,7 @@ function fastifyWebsocket (fastify, opts, next) {
           result = globalHandler.call(fastify, request.raw[kWs], request.raw)
         }
         if (result && typeof result.catch === 'function') {
-          result.catch(err => errorHandler.call(this, request.raw[kWs], err))
+          result.catch(err => errorHandler.call(this, err, request.raw[kWs]))
         }
       } else {
         return handler.call(fastify, request, reply)
@@ -110,7 +110,7 @@ function fastifyWebsocket (fastify, opts, next) {
     req[kWs].socket.close()
   }
 
-  function defaultErrorHandler (conn, error) {
+  function defaultErrorHandler (error, conn) {
     // Before destroying the connection, we attach an error listener.
     // Since we already handled the error, adding this listener prevents the ws
     // library from emitting the error and causing an uncaughtException
@@ -125,7 +125,7 @@ function fastifyWebsocket (fastify, opts, next) {
     if (req[kWs]) {
       const result = globalHandler.call(fastify, req[kWs], req)
       if (result && typeof result.catch === 'function') {
-        result.catch(err => errorHandler.call(this, req[kWs], err))
+        result.catch(err => errorHandler.call(this, err, req[kWs]))
       }
     } else {
       return oldDefaultRoute(req, res)

--- a/index.js
+++ b/index.js
@@ -111,6 +111,11 @@ function fastifyWebsocket (fastify, opts, next) {
   }
 
   function defaultErrorHandler (conn, error) {
+    // Before destroying the connection, we attach an error listener.
+    // Since we already handled the error, adding this listener prevents the ws
+    // library from emitting the error and causing an uncaughtException
+    // Reference: https://github.com/websockets/ws/blob/master/lib/stream.js#L35
+    conn.on('error', _ => {})
     conn.destroy(error)
   }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "find-my-way": "^3.0.4",
     "ws": "^7.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fastify": "ayoubelk/fastify#websocket-fastifyrequest",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
+    "split2": "^3.2.2",
     "standard": "^16.0.1",
     "tap": "^14.10.8",
     "tsd": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
     "@types/ws": "^7.4.0",
-    "fastify": "ayoubelk/fastify#websocket-fastifyrequest",
+    "fastify": "^3.11.0",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "split2": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
     "@types/ws": "^7.2.7",
-    "fastify": "^3.0.2",
+    "fastify": "ayoubelk/fastify#websocket-fastifyrequest",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "standard": "^16.0.1",

--- a/test/base.js
+++ b/test/base.js
@@ -75,7 +75,7 @@ test('Should run custom errorHandler on global handler error', (t) => {
 
   const options = {
     handle,
-    errorHandler: function (connection, error) {
+    errorHandler: function (error, connection) {
       t.equal(error.message, 'Fail')
     }
   }
@@ -104,7 +104,7 @@ test('Should run custom errorHandler on websocket handler error', (t) => {
   t.tearDown(() => fastify.close())
 
   const options = {
-    errorHandler: function (connection, error) {
+    errorHandler: function (error, connection) {
       t.equal(error.message, 'Fail')
     }
   }

--- a/test/base.js
+++ b/test/base.js
@@ -179,7 +179,7 @@ test('Should warn if path option is provided to websocket-stream', (t) => {
 
   t.tearDown(() => fastify.close())
 
-  const options = { path: 'my-path' }
+  const options = { path: '/' }
   fastify.register(fastifyWebsocket, { options })
 
   fastify.get('/*', { websocket: true }, (connection, request) => {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -76,33 +76,31 @@ test('Should run onTimeout hook', t => {
 })
 
 test('Should run onError hook before handler is executed (error thrown in onRequest hook)', t => {
-  t.plan(4)
+  t.plan(3)
   const fastify = Fastify()
 
   t.tearDown(() => fastify.close())
 
   fastify.register(fastifyWebsocket)
 
-  const uncaughtException = new Error('uncaught')
-  fastify.addHook('onRequest', async (request, reply) => { throw uncaughtException })
+  fastify.addHook('onRequest', async (request, reply) => { throw new Error('Fail') })
   fastify.addHook('onError', async (request, reply) => t.ok('called', 'onError'))
 
   fastify.get('/echo', { websocket: true }, (conn, request) => {
     t.tearDown(conn.destroy.bind(conn))
-    t.fail('called', 'websocket handler')
   })
 
-  t.expectUncaughtException(fastify.listen(0, err => {
+  fastify.listen(0, function (err) {
     t.error(err)
     const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
     const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(client.destroy.bind(client))
     ws.on('close', code => t.equal(code, 1006))
-  }), uncaughtException)
+  })
 })
 
-test('Should not run onError hook if reply was hijacked (error thrown in websocket handler, expected uncaughtException)', t => {
-  t.plan(3)
+test('Should not run onError hook if reply was already hijacked (error thrown in websocket handler)', t => {
+  t.plan(2)
   const fastify = Fastify()
 
   t.tearDown(() => fastify.close())
@@ -111,19 +109,18 @@ test('Should not run onError hook if reply was hijacked (error thrown in websock
 
   fastify.addHook('onError', async (request, reply) => t.fail('called', 'onError'))
 
-  const uncaughtException = new Error('uncaught')
   fastify.get('/echo', { websocket: true }, async (conn, request) => {
     t.tearDown(conn.destroy.bind(conn))
-    throw uncaughtException
+    throw new Error('Fail')
   })
 
-  t.expectUncaughtException(fastify.listen(0, err => {
+  fastify.listen(0, function (err) {
     t.error(err)
     const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
     const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
     t.tearDown(client.destroy.bind(client))
     ws.on('close', code => t.equal(code, 1006))
-  }), uncaughtException)
+  })
 })
 
 test('Should not run preSerialization/onSend hooks', t => {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('tap').test
+const net = require('net')
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
@@ -58,7 +59,7 @@ test('Should run onTimeout hook', t => {
   fastify.get('/echo', { websocket: true }, (conn, request) => {
     conn.setEncoding('utf8')
     conn.write('hello client')
-    request.raw.setTimeout(100)
+    request.raw.setTimeout(50)
     t.tearDown(conn.destroy.bind(conn))
   })
 
@@ -70,6 +71,114 @@ test('Should run onTimeout hook', t => {
 
     client.once('data', chunk => {
       t.equal(chunk, 'hello client')
+    })
+  })
+})
+
+test('Should run onError hook before handler is executed (error thrown in onRequest hook)', t => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+
+  const uncaughtException = new Error('uncaught')
+  fastify.addHook('onRequest', async (request, reply) => { throw uncaughtException })
+  fastify.addHook('onError', async (request, reply) => t.ok('called', 'onError'))
+
+  fastify.get('/echo', { websocket: true }, (conn, request) => {
+    t.tearDown(conn.destroy.bind(conn))
+    t.fail('called', 'websocket handler')
+  })
+
+  t.expectUncaughtException(fastify.listen(0, err => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+    t.tearDown(client.destroy.bind(client))
+    ws.on('close', code => t.equal(code, 1006))
+  }), uncaughtException)
+})
+
+test('Should not run onError hook if reply was hijacked (error thrown in websocket handler, expected uncaughtException)', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+
+  fastify.addHook('onError', async (request, reply) => t.fail('called', 'onError'))
+
+  const uncaughtException = new Error('uncaught')
+  fastify.get('/echo', { websocket: true }, async (conn, request) => {
+    t.tearDown(conn.destroy.bind(conn))
+    throw uncaughtException
+  })
+
+  t.expectUncaughtException(fastify.listen(0, err => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+    t.tearDown(client.destroy.bind(client))
+    ws.on('close', code => t.equal(code, 1006))
+  }), uncaughtException)
+})
+
+test('Should not run preSerialization/onSend hooks', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+
+  fastify.addHook('onSend', async (request, reply) => t.fail('called', 'onSend'))
+  fastify.addHook('preSerialization', async (request, reply) => t.fail('called', 'preSerialization'))
+
+  fastify.get('/echo', { websocket: true }, async (conn, request) => {
+    conn.setEncoding('utf8')
+    conn.write('hello client')
+    t.tearDown(conn.destroy.bind(conn))
+    conn.end()
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+    t.tearDown(client.destroy.bind(client))
+
+    client.once('data', chunk => {
+      t.equal(chunk, 'hello client')
+      client.end()
+    })
+  })
+})
+
+test('Should not hijack reply for a normal http request in the internal onError hook', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+
+  fastify.get('/', async (request, reply) => {
+    throw new Error('Fail')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    const port = fastify.server.address().port
+
+    const httpClient = net.createConnection({ port: port }, () => {
+      httpClient.write('GET / HTTP/1.1\r\n\r\n')
+      httpClient.once('data', data => {
+        t.match(data.toString(), /Fail/i)
+      })
     })
   })
 })

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -46,15 +46,15 @@ test('Should run onRequest, preParsing, preValidation, preHandler hooks', t => {
   })
 })
 
-test('Should run onTimeout hook', t => {
-  t.plan(3)
+test('Should not run onTimeout hook', t => {
+  t.plan(2)
   const fastify = Fastify()
 
   t.tearDown(() => fastify.close())
 
   fastify.register(fastifyWebsocket)
 
-  fastify.addHook('onTimeout', async (request, reply) => t.ok('called', 'onTimeout'))
+  fastify.addHook('onTimeout', async (request, reply) => t.fail('called', 'onTimeout'))
 
   fastify.get('/echo', { websocket: true }, (conn, request) => {
     conn.setEncoding('utf8')

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const test = require('tap').test
+const Fastify = require('fastify')
+const fastifyWebsocket = require('..')
+const WebSocket = require('ws')
+
+test('Should run onRequest, preParsing, preValidation, preHandler hooks', t => {
+  t.plan(7)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+
+  fastify.addHook('onRequest', async (request, reply) => t.ok('called', 'onRequest'))
+  fastify.addHook('preParsing', async (request, reply, payload) => t.ok('called', 'preParsing'))
+  fastify.addHook('preValidation', async (request, reply) => t.ok('called', 'preValidation'))
+  fastify.addHook('preHandler', async (request, reply) => t.ok('called', 'preHandler'))
+
+  fastify.get('/echo', { websocket: true }, (conn, request) => {
+    conn.setEncoding('utf8')
+    conn.write('hello client')
+    t.tearDown(conn.destroy.bind(conn))
+
+    conn.once('data', chunk => {
+      t.equal(chunk, 'hello server')
+      conn.end()
+    })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+    t.tearDown(client.destroy.bind(client))
+
+    client.setEncoding('utf8')
+    client.write('hello server')
+
+    client.once('data', chunk => {
+      t.equal(chunk, 'hello client')
+      client.end()
+    })
+  })
+})
+
+test('Should run onTimeout hook', t => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  t.tearDown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket)
+
+  fastify.addHook('onTimeout', async (request, reply) => t.ok('called', 'onTimeout'))
+
+  fastify.get('/echo', { websocket: true }, (conn, request) => {
+    conn.setEncoding('utf8')
+    conn.write('hello client')
+    request.raw.setTimeout(100)
+    t.tearDown(conn.destroy.bind(conn))
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+    t.tearDown(client.destroy.bind(client))
+
+    client.once('data', chunk => {
+      t.equal(chunk, 'hello client')
+    })
+  })
+})

--- a/test/router.js
+++ b/test/router.js
@@ -2,7 +2,6 @@
 
 const net = require('net')
 const test = require('tap').test
-// const only = require('tap').only
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')

--- a/test/router.js
+++ b/test/router.js
@@ -319,7 +319,7 @@ test('Should pass route params to handlers', t => {
     )
     const client2 = WebSocket.createWebSocketStream(ws2, { encoding: 'utf8' })
     t.tearDown(client.destroy.bind(client))
-    t.tearDown(client2.destroy.bind(client))
+    t.tearDown(client2.destroy.bind(client2))
 
     client.setEncoding('utf8')
     client2.setEncoding('utf8')

--- a/test/router.js
+++ b/test/router.js
@@ -296,12 +296,14 @@ test('Should pass route params to handlers', t => {
   t.tearDown(() => fastify.close())
 
   fastify.register(fastifyWebsocket)
-  fastify.get('/ws', { websocket: true }, (conn, req, params) => {
+  fastify.get('/ws', { websocket: true }, (conn, req) => {
+    const params = req.params
     t.equal(Object.keys(params).length, 0, 'params are empty')
     conn.write('empty')
     conn.end()
   })
-  fastify.get('/ws/:id', { websocket: true }, (conn, req, params) => {
+  fastify.get('/ws/:id', { websocket: true }, (conn, req) => {
+    const params = req.params
     t.equal(params.id, 'foo', 'params are correct')
     conn.write(params.id)
     conn.end()

--- a/test/router.js
+++ b/test/router.js
@@ -374,38 +374,6 @@ test('Should not thow error when register empty get with prefix', t => {
   })
 })
 
-test('Should expose fastify instance to websocket global handler', t => {
-  const fastify = Fastify()
-
-  t.tearDown(() => fastify.close())
-
-  fastify.register(fastifyWebsocket, {
-    handle: function wsHandler (conn, req) {
-      t.equal(this, fastify, 'this is bound to fastify server')
-      conn.write('empty')
-      conn.end()
-    },
-    options: { path: '/ws' }
-  })
-
-  fastify.listen(0, err => {
-    t.error(err)
-    const ws = new WebSocket(
-      'ws://localhost:' + (fastify.server.address()).port + '/ws'
-    )
-    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-    t.tearDown(client.destroy.bind(client))
-
-    client.setEncoding('utf8')
-
-    client.once('data', chunk => {
-      t.equal(chunk, 'empty')
-      client.end()
-      t.end()
-    })
-  })
-})
-
 test('Should expose fastify instance to websocket per-route handler', t => {
   const fastify = Fastify()
 

--- a/test/router.js
+++ b/test/router.js
@@ -108,13 +108,17 @@ test('Should expose websocket and http route', t => {
   })
 })
 
-test('Should close on unregistered path (with no wildcard route handler defined)', t => {
+test('Should close on unregistered path (with no wildcard route websocket handler defined)', t => {
   t.plan(2)
   const fastify = Fastify()
 
   t.tearDown(() => fastify.close())
 
   fastify.register(fastifyWebsocket)
+
+  fastify.get('/*', (request, reply) => {
+    reply.send('hello world')
+  })
 
   fastify.get('/echo', { websocket: true }, (connection, request) => {
     connection.socket.on('message', message => {

--- a/test/router.js
+++ b/test/router.js
@@ -2,6 +2,7 @@
 
 const net = require('net')
 const test = require('tap').test
+// const only = require('tap').only
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
@@ -236,17 +237,17 @@ test('Should call the global handler if a non-websocket route with path exists',
   const fastify = Fastify()
   t.tearDown(() => fastify.close())
 
-  fastify.get('/http', (request, reply) => {
-    t.ok('Should not call http handler')
-    reply.send('http route')
-  })
-
   fastify.register(fastifyWebsocket, {
     handle: (conn, req) => {
       t.ok('called', 'global handler')
       conn.write('global handler')
       t.tearDown(conn.destroy.bind(conn))
     }
+  })
+
+  fastify.get('/http', (request, reply) => {
+    t.fail('Should not call http handler')
+    reply.send('http route')
   })
 
   fastify.listen(0, err => {
@@ -256,10 +257,6 @@ test('Should call the global handler if a non-websocket route with path exists',
     t.tearDown(client.destroy.bind(client))
 
     client.setEncoding('utf8')
-    // client.on('data', data => {
-    //   t.equal(data, 'global handler')
-    //   client.end(() => { t.end() })
-    // })
     client.end(() => { t.end() })
   })
 })

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -9,10 +9,12 @@ app.register(wsPlugin);
 app.register(wsPlugin, {});
 app.register(wsPlugin, { options: { maxPayload: 123 } });
 app.register(wsPlugin, {
-  errorHandler: function errorHandler(error: Error, connection: SocketStream): void {
+  errorHandler: function errorHandler(error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply): void {
     expectType<FastifyInstance>(this);
     expectType<Error>(error)
-    expectType<SocketStream>(connection);
+    expectType<SocketStream>(connection)
+    expectType<FastifyRequest>(request)
+    expectType<FastifyReply>(reply)
   }
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -14,10 +14,10 @@ app.register(wsPlugin, {
     expectType<SocketStream>(connection);
     expectType<IncomingMessage>(req)
   },
-  errorHandler: function errorHandler(connection: SocketStream, error: Error): void {
+  errorHandler: function errorHandler(error: Error, connection: SocketStream): void {
     expectType<FastifyInstance>(this);
-    expectType<SocketStream>(connection);
     expectType<Error>(error)
+    expectType<SocketStream>(connection);
   }
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -9,11 +9,6 @@ app.register(wsPlugin);
 app.register(wsPlugin, {});
 app.register(wsPlugin, { options: { maxPayload: 123 } });
 app.register(wsPlugin, {
-  handle: function globalHandler(connection: SocketStream, req: IncomingMessage): void {
-    expectType<FastifyInstance>(this);
-    expectType<SocketStream>(connection);
-    expectType<IncomingMessage>(req)
-  },
   errorHandler: function errorHandler(error: Error, connection: SocketStream): void {
     expectType<FastifyInstance>(this);
     expectType<Error>(error)

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,5 @@
 import wsPlugin, { WebsocketHandler, SocketStream } from '../..';
-import fastify, { RouteOptions, FastifyRequest, FastifyInstance, RequestGenericInterface, FastifyReply } from 'fastify';
-import { IncomingMessage } from 'http'
+import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply } from 'fastify';
 import { expectType } from 'tsd';
 import { Server } from 'ws';
 

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -13,6 +13,11 @@ app.register(wsPlugin, {
     expectType<FastifyInstance>(this);
     expectType<SocketStream>(connection);
     expectType<IncomingMessage>(req)
+  },
+  errorHandler: function errorHandler(connection: SocketStream, error: Error): void {
+    expectType<FastifyInstance>(this);
+    expectType<SocketStream>(connection);
+    expectType<Error>(error)
   }
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,5 +1,6 @@
 import wsPlugin, { WebsocketHandler, SocketStream } from '../..';
 import fastify, { RouteOptions, FastifyRequest, FastifyInstance, RequestGenericInterface, FastifyReply } from 'fastify';
+import { IncomingMessage } from 'http'
 import { expectType } from 'tsd';
 import { Server } from 'ws';
 
@@ -8,9 +9,10 @@ app.register(wsPlugin);
 app.register(wsPlugin, {});
 app.register(wsPlugin, { options: { maxPayload: 123 } });
 app.register(wsPlugin, {
-  handle: function globalHandler(connection: SocketStream): void {
+  handle: function globalHandler(connection: SocketStream, req: IncomingMessage): void {
     expectType<FastifyInstance>(this);
-    expectType<SocketStream>(connection)
+    expectType<SocketStream>(connection);
+    expectType<IncomingMessage>(req)
   }
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,7 +1,6 @@
 import wsPlugin, { WebsocketHandler, SocketStream } from '../..';
 import fastify, { RouteOptions, FastifyRequest, FastifyInstance, RequestGenericInterface, FastifyReply } from 'fastify';
 import { expectType } from 'tsd';
-import { Server as HttpServer, IncomingMessage } from 'http'
 import { Server } from 'ws';
 
 const app: FastifyInstance = fastify();
@@ -16,19 +15,17 @@ app.register(wsPlugin, {
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });
 
-app.get('/websockets-via-inferrence', { websocket: true }, async function(connection, req, params) {
+app.get('/websockets-via-inferrence', { websocket: true }, async function(connection, request) {
   expectType<FastifyInstance>(this);
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
-  expectType<IncomingMessage>(req)
-  expectType<{ [key: string]: any } | undefined>(params);
+  expectType<FastifyRequest>(request)
 });
 
-const handler: WebsocketHandler = async (connection, req, params) => {
+const handler: WebsocketHandler = async (connection, request) => {
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
-  expectType<IncomingMessage>(req)
-  expectType<{ [key: string]: any } | undefined>(params);
+  expectType<FastifyRequest>(request)
 }
 
 app.get('/websockets-via-annotated-const', { websocket: true }, handler);
@@ -50,10 +47,9 @@ app.route({
     expectType<FastifyRequest>(request);
     expectType<FastifyReply>(reply);
   },
-  wsHandler: (connection, req, params) => {
+  wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
-    expectType<IncomingMessage>(req)
-    expectType<{ [key: string]: any } | undefined>(params);
+    expectType<FastifyRequest>(request);
   },
 });
 
@@ -64,10 +60,9 @@ const augmentedRouteOptions: RouteOptions = {
     expectType<FastifyRequest>(request);
     expectType<FastifyReply>(reply);
   },
-  wsHandler: (connection, req, params) => {
+  wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
-    expectType<IncomingMessage>(req)
-    expectType<{ [key: string]: any } | undefined>(params);
+    expectType<FastifyRequest>(request)
   },
 };
 app.route(augmentedRouteOptions);


### PR DESCRIPTION
This is about [fastify/fastify-websocket/#70](https://github.com/fastify/fastify-websocket/issues/70), it closes #70 and is dependent on the changes here [fastify/fastify/#2733](https://github.com/fastify/fastify/pull/2733)

#### This:
- removes the internal find-my-way router used for websocket routes
- dispatches websocket incoming connections through the normal fastify request cycle
- runs all hooks up to handler execution
- allows access to FastifyRequest object inside websocket handlers

#### Implementation details:
- In order to run the hooks and create the necessary internals objects `FastifyRequest`, `FastifyReply`, and `Context`, the incoming connection needs to be dispatched to the fastify instance router. This was done by updating the fastify repository in order to expose the routing utility (precisely the `httpHandler` function in `fastify.js`)
- In the `onRoute` hook, a wrapper-handler is created and an if-else statement is used to allow checking if we're handling a normal http request or websocket connection, and either run `handler` or `wsHandler`
- In order to only run the hooks up to handler execution, I followed @airhorns  suggestion and added a `Reply.hijack()` method to `FastifyReply` which marks it as hijacked, this allows plugins to exit the `Reply.send()` method and skip the execution of remaining hooks
- The global handler is still supported, however it receives as a param a req object of type `IncomingMessage`, this is because no match was find and we use the `defaultRoute` function instead of the `routeHandler` which creates the `FastifyRequest`, `FastifyReply`, and `Context` objects. Also, in order to support this global handler, we needed a way to override the fastify `defaultRoute` function and handle websocket connections as well instead of defaulting to `FourOhFour` router lookup. This was done by exposing it from the fastify instance and monkeypatching it inside the plugin.

Looking forward to your feedback!
Thanks

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
