### PR TITLE
Close the fastify server before closing clients.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,28 +83,23 @@ function fastifyWebsocket (fastify, opts, next) {
 
   fastify.addHook('onClose', close)
 
+  let closing = false
+
   // Fastify is missing a pre-close event, or the ability to
   // add a hook before the server.close call. We need to resort
   // to monkeypatching for now.
   const oldClose = fastify.server.close
   fastify.server.close = function (cb) {
+    closing = true
+
     // Call oldClose first so that we stop listening. This ensures the
     // server.clients list will be up to date when we start closing below.
     oldClose.call(this, cb)
 
-    function closeAllClients () {
-      if (fastify.server.listening) {
-        setTimeout(closeAllClients, 0)
-        return
-      }
-
-      const server = fastify.websocketServer
-      for (const client of server.clients) {
-        client.close()
-      }
+    const server = fastify.websocketServer
+    for (const client of server.clients) {
+      client.close()
     }
-
-    closeAllClients()
   }
 
   function noHandle (conn, req) {
@@ -132,6 +127,11 @@ function fastifyWebsocket (fastify, opts, next) {
   })
 
   function handleRouting (connection, request) {
+    if (closing) {
+      connection.close(1001)
+      return
+    }
+
     const response = new ServerResponse(request)
     request[kWs] = WebSocket.createWebSocketStream(connection)
     request[kWs].socket = connection

--- a/index.js
+++ b/index.js
@@ -92,10 +92,19 @@ function fastifyWebsocket (fastify, opts, next) {
     // server.clients list will be up to date when we start closing below.
     oldClose.call(this, cb)
 
-    const server = fastify.websocketServer
-    for (const client of server.clients) {
-      client.close()
+    function closeAllClients () {
+      if (fastify.server.listening) {
+        setTimeout(closeAllClients, 0)
+        return
+      }
+
+      const server = fastify.websocketServer
+      for (const client of server.clients) {
+        client.close()
+      }
     }
+
+    closeAllClients()
   }
 
   function noHandle (conn, req) {

--- a/index.js
+++ b/index.js
@@ -88,11 +88,14 @@ function fastifyWebsocket (fastify, opts, next) {
   // to monkeypatching for now.
   const oldClose = fastify.server.close
   fastify.server.close = function (cb) {
+    // Call oldClose first so that we stop listening. This ensures the
+    // server.clients list will be up to date when we start closing below.
+    oldClose.call(this, cb)
+
     const server = fastify.websocketServer
     for (const client of server.clients) {
       client.close()
     }
-    oldClose.call(this, cb)
   }
 
   function noHandle (conn, req) {


### PR DESCRIPTION
This avoids any race conditions where new websocket connections come in between the loop that closes all existing clients and the server no longer listening for new connections.

We observed this in one of our end-to-end test suites, where we have some out-of-process services that use reconnecting websockets. Setting up a `setInterval` that printed `server.clients.size` showed that it was not empty before this change, but was empty after this change.

@mcollina thought you'd be interested in seeing this one, since you introduced this code :)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
