### PR TITLE
fix: make ws types non-dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
-    "@types/ws": "^7.4.0",
     "fastify": "^3.11.0",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
@@ -39,6 +38,7 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
+    "@types/ws": "^7.4.0",
     "fastify-plugin": "^3.0.0",
     "ws": "^7.4.2"
   }


### PR DESCRIPTION
As `@types/ws` are included in `devDependencies`, npm won't install it for end-users. This results in missing types:

https://github.com/fastify/fastify-websocket/blob/a825ffcd5838bd693cd65d7691428c6c2dac4d3a/index.d.ts#L5

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
