### PR TITLE
Don't lose messages when hooks are asynchronous

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const { ServerResponse } = require('http')
 const fp = require('fastify-plugin')
 const WebSocket = require('ws')
 
-const kWs = Symbol('ws')
+const kWs = Symbol('ws-socket')
+const kWsHead = Symbol('ws-head')
 
 function fastifyWebsocket (fastify, opts, next) {
   let errorHandler = defaultErrorHandler
@@ -16,25 +17,65 @@ function fastifyWebsocket (fastify, opts, next) {
     errorHandler = opts.errorHandler
   }
 
-  const options = Object.assign({}, opts.options)
-  if (options.path) {
+  if (opts.options && opts.options.noServer) {
+    return next(new Error("fastify-websocket doesn't support the ws noServer option. If you want to create a websocket server detatched from fastify, use the ws library directly."))
+  }
+
+  const wssOptions = Object.assign({ noServer: true }, opts.options)
+
+  if (wssOptions.path) {
     fastify.log.warn('ws server path option shouldn\'t be provided, use a route instead')
   }
-  if (!options.server && !options.noServer) {
-    options.server = fastify.server
-  }
 
-  const wss = new WebSocket.Server(options)
-  wss.on('connection', handleRouting)
+  // We always handle upgrading ourselves in this library so that we can dispatch through the fastify stack before actually upgrading
+  // For this reason, we run the WebSocket.Server in noServer mode, and prevent the user from passing in a http.Server instance for it to attach to.
+  // Usually, we listen to the upgrade event of the `fastify.server`, but we do still support this server option by just listening to upgrades on it if passed.
+  const websocketListenServer = wssOptions.server || fastify.server
+  delete wssOptions.server
 
+  const wss = new WebSocket.Server(wssOptions)
   fastify.decorate('websocketServer', wss)
+
+  websocketListenServer.on('upgrade', (rawRequest, socket, head) => {
+    // Save a reference to the socket and then dispatch the request through the normal fastify router so that it will invoke hooks and then eventually a route handler that might upgrade the socket.
+    rawRequest[kWs] = socket
+    rawRequest[kWsHead] = head
+
+    if (closing) {
+      handleUpgrade(rawRequest, (connection) => {
+        connection.socket.close(1001)
+      })
+    } else {
+      const rawResponse = new ServerResponse(rawRequest)
+      fastify.routing(rawRequest, rawResponse)
+    }
+  })
+
+  const handleUpgrade = (rawRequest, callback) => {
+    wss.handleUpgrade(rawRequest, rawRequest[kWs], rawRequest[kWsHead], (socket) => {
+      wss.emit('connection', socket, rawRequest)
+
+      const connection = WebSocket.createWebSocketStream(socket)
+      connection.socket = socket
+
+      connection.socket.on('newListener', event => {
+        if (event === 'message') {
+          connection.resume()
+        }
+      })
+
+      callback(connection)
+    })
+  }
 
   fastify.addHook('onError', (request, reply, error, done) => {
     if (request.raw[kWs]) {
       // Hijack reply to prevent fastify from sending the error after onError hooks are done running
       reply.hijack()
-      // Handle the error
-      errorHandler.call(this, error, request.raw[kWs], request, reply)
+      handleUpgrade(request.raw, connection => {
+        // Handle the error
+        errorHandler.call(this, error, connection, request, reply)
+      })
     }
     done()
   })
@@ -63,18 +104,23 @@ function fastifyWebsocket (fastify, opts, next) {
       }
     }
 
+    // we always override the route handler so we can close websocket connections to routes to handlers that don't support websocket connections
     routeOptions.handler = (request, reply) => {
+      // within the route handler, we check if there has been a connection upgrade by looking at request.raw[kWs]. we need to dispatch the normal HTTP handler if not, and hijack to dispatch the websocket handler if so
       if (request.raw[kWs]) {
         reply.hijack()
-        let result
-        if (isWebsocketRoute) {
-          result = wsHandler.call(fastify, request.raw[kWs], request)
-        } else {
-          result = noHandle.call(fastify, request.raw[kWs], request.raw)
-        }
-        if (result && typeof result.catch === 'function') {
-          result.catch(err => errorHandler.call(this, err, request.raw[kWs], request, reply))
-        }
+        handleUpgrade(request.raw, connection => {
+          let result
+          if (isWebsocketRoute) {
+            result = wsHandler.call(fastify, connection, request)
+          } else {
+            result = noHandle.call(fastify, connection, request)
+          }
+
+          if (result && typeof result.catch === 'function') {
+            result.catch(err => errorHandler.call(this, err, connection, request, reply))
+          }
+        })
       } else {
         return handler.call(fastify, request, reply)
       }
@@ -102,9 +148,9 @@ function fastifyWebsocket (fastify, opts, next) {
     }
   }
 
-  function noHandle (conn, req) {
-    this.log.info({ path: req.url }, 'closed incoming websocket connection')
-    req[kWs].socket.close()
+  function noHandle (connection, rawRequest) {
+    this.log.info({ path: rawRequest.url }, 'closed incoming websocket connection for path with no websocket handler')
+    connection.socket.close()
   }
 
   function defaultErrorHandler (error, conn, request, reply) {
@@ -120,30 +166,13 @@ function fastifyWebsocket (fastify, opts, next) {
   const oldDefaultRoute = fastify.getDefaultRoute()
   fastify.setDefaultRoute(function (req, res) {
     if (req[kWs]) {
-      noHandle.call(fastify, req[kWs], req)
+      handleUpgrade(req, (connection) => {
+        noHandle.call(fastify, connection, req)
+      })
     } else {
       return oldDefaultRoute(req, res)
     }
   })
-
-  function handleRouting (connection, request) {
-    if (closing) {
-      connection.close(1001)
-      return
-    }
-
-    const response = new ServerResponse(request)
-    request[kWs] = WebSocket.createWebSocketStream(connection)
-    request[kWs].socket = connection
-
-    request[kWs].socket.on('newListener', event => {
-      if (event === 'message') {
-        request[kWs].resume()
-      }
-    })
-
-    fastify.routing(request, response)
-  }
 
   next()
 }

--- a/test/base.js
+++ b/test/base.js
@@ -472,55 +472,10 @@ test('Should keep processing message when many medium sized messages are sent', 
   })
 })
 
-test('Should not set server if noServer option is set', (t) => {
-  t.plan(5)
-
+test('Should error server if the noServer option is set', (t) => {
+  t.plan(1)
   const fastify = Fastify()
-  t.tearDown(() => {
-    fastify.close()
-  })
 
-  const options = {
-    noServer: true
-  }
-
-  fastify.register(fastifyWebsocket, { options })
-
-  // this is all that's needed to create an echo server
-  fastify.get('/', { websocket: true }, (connection, request) => {
-    connection.pipe(connection)
-    t.tearDown(() => connection.destroy())
-  })
-
-  // As the websocketserver is now completely detached, we have to
-  // handle the upgrade event.
-  fastify.ready((err) => {
-    t.error(err)
-
-    t.assert(!fastify.websocketServer.server)
-
-    fastify.server.on('upgrade', (request, socket, head) => {
-      fastify.websocketServer.handleUpgrade(request, socket, head, (ws) => {
-        fastify.websocketServer.emit('connection', ws, request)
-      })
-    })
-  })
-
-  fastify.listen(0, (err) => {
-    t.error(err)
-
-    const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-    t.tearDown(() => client.destroy())
-
-    client.setEncoding('utf8')
-    client.write('hello')
-
-    client.once('data', (chunk) => {
-      t.equal(chunk, 'hello')
-      fastify.close(function (err) {
-        t.error(err)
-      })
-    })
-  })
+  fastify.register(fastifyWebsocket, { options: { noServer: true } })
+  t.rejects(fastify.ready())
 })


### PR DESCRIPTION
New in version `3.0.0`, we run the fastify hooks for the request before handing the constructed websocket over to the route handler. Before this change, `fastify-websocket` processed the `UPGRADE` request from the client before dispatching the request to the router. This means it created the `WebSocket` object and the duplex stream wrapping it before invoking all the userland code that might want to do stuff in hooks like authentication, or loading a session, or whatever. 

If those hooks that run after the creation of the websocket are asynchronous, that means that the websocket that has already been set up and connected can receive messages during the execution of those async hooks. Generally I think developers would attach onMessage handlers in their route handler functions. If they do that, those message handler functions wouldn't be attached until after all the pre-route handlers have been run, which would mean any messages that arrive during hook processing won't trigger any message handlers and get silently dropped!

Instead, we should buffer any incoming messages until the userland route handler is ready to work with the WebSocket, and give it the chance to synchronously attach event listeners. The `net.Socket` will buffer any messages, and then the `ws` library will dispatch them as messages on the next process tick after setting up the `WebSocket` instance. The handler will run in between there and get a chance to register listeners. Hooks won't have access to the websocket if we do this, but they already didn't, and I think this is a big enough gotcha that that's fine.

To implement this, we stop using the `connection` event of the `ws` server, and instead listen to the `upgrade` event of the `http.Server`, and still dispatch that request through fastify. Then, in the route handler, we use `wss.handleUpgradeRequest` to create the WebSocket. The upgrade runs after all the hooks are done, and then synchronously passes in the `WebSocket` instance to the route handler, allowing it to get the handlers registered in time for any messages coming off the buffer. 

This means that the `ws` server runs without actually attaching to an `http.Server`, which I think makes sense since we want finer control over when the upgrade is actually handled.  Because this requires some special options to be passed to the `ws` server, I opted to remove support for the `noServer` option to the ws server. I think this is fine -- it seems kind of strange to use a http sever plugin to register a websocket system that you don't want listening using that http server, but it is a breaking change. We still support the custom `server` option that gets passed through to `ws`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
