### PR TITLE
Improve request type in ws handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module 'fastify' {
     <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault>(
       path: string,
       opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> & { websocket: true }, // this creates an overload that only applies these different types if the handler is for websockets
-      handler?: WebsocketHandler
+      handler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric>
     ): FastifyInstance<RawServer, RawRequest, RawReply>;
   }
 
@@ -41,10 +41,14 @@ declare const websocketPlugin: FastifyPluginCallback<WebsocketPluginOptions>;
 interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, 'path'> {}
 
 
-export type WebsocketHandler = (
+export type WebsocketHandler<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface
+> = (
   this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   connection: SocketStream,
-  request: FastifyRequest,
+  request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
 ) => void | Promise<any>;
 
 export interface SocketStream extends Duplex {

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,11 +44,11 @@ interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, 'path'> {
 export type WebsocketHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
-  RouteGeneric extends RouteGenericInterface = RouteGenericInterface
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface
 > = (
   this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   connection: SocketStream,
-  request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+  request: FastifyRequest<RequestGeneric, RawServer, RawRequest>,
 ) => void | Promise<any>;
 
 export interface SocketStream extends Duplex {

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import wsPlugin, { WebsocketHandler, SocketStream } from '../..';
-import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply } from 'fastify';
+import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface } from 'fastify';
 import { expectType } from 'tsd';
 import { Server } from 'ws';
 
@@ -22,13 +22,13 @@ app.get('/websockets-via-inferrence', { websocket: true }, async function(connec
   expectType<FastifyInstance>(this);
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
-  expectType<FastifyRequest>(request)
+  expectType<FastifyRequest<RequestGenericInterface>>(request)
 });
 
 const handler: WebsocketHandler = async (connection, request) => {
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
-  expectType<FastifyRequest>(request)
+  expectType<FastifyRequest<RequestGenericInterface>>(request)
 }
 
 app.get('/websockets-via-annotated-const', { websocket: true }, handler);
@@ -52,7 +52,7 @@ app.route({
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
-    expectType<FastifyRequest>(request);
+    expectType<FastifyRequest<RequestGenericInterface>>(request);
   },
 });
 
@@ -65,7 +65,7 @@ const augmentedRouteOptions: RouteOptions = {
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
-    expectType<FastifyRequest>(request)
+    expectType<FastifyRequest<RequestGenericInterface>>(request)
   },
 };
 app.route(augmentedRouteOptions);


### PR DESCRIPTION
Improves typing of the ws request handler. Passing generics here allows typing params, e.g. 
```ts
fastify.get<{ Params: { id: string } }>(
  '/:id',
  { websocket: true },
  (conn, req) => {
    req.params.id // typechecks!
  }
)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
