### PR TITLE
Run error handler when an error occurs in a non-async handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,10 +111,15 @@ function fastifyWebsocket (fastify, opts, next) {
         reply.hijack()
         handleUpgrade(request.raw, connection => {
           let result
-          if (isWebsocketRoute) {
-            result = wsHandler.call(fastify, connection, request)
-          } else {
-            result = noHandle.call(fastify, connection, request)
+
+          try {
+            if (isWebsocketRoute) {
+              result = wsHandler.call(fastify, connection, request)
+            } else {
+              result = noHandle.call(fastify, connection, request)
+            }
+          } catch (err) {
+            return errorHandler.call(this, err, connection, request, reply)
           }
 
           if (result && typeof result.catch === 'function') {


### PR DESCRIPTION
fixes #119

I basically duplicated the other test and removed the `async` keyword. Without the fix the test would timeout.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
