### PR TITLE
Ensure clients exists before iterating

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,9 +147,11 @@ function fastifyWebsocket (fastify, opts, next) {
     // server.clients list will be up to date when we start closing below.
     oldClose.call(this, cb)
 
-    const server = fastify.websocketServer
-    for (const client of server.clients) {
-      client.close()
+    const clients = fastify.websocketServer.clients
+    if (typeof clients !== 'undefined') {
+      for (const client of clients) {
+        client.close()
+      }
     }
   }
 


### PR DESCRIPTION
For some reason I'm getting `TypeError: server.clients is not iterable` and `wsServer.clients` is undefined when trying to close the fastify server after running tests with a real WS client.

Even without this weird problem this check should be there, because if `clientTracking` is disabled this property will not exist.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
