### PR TITLE
check for server.clients undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ function fastifyWebsocket (fastify, opts, next) {
     oldClose.call(this, cb)
 
     const server = fastify.websocketServer
+    if (!server.clients) return
     for (const client of server.clients) {
       client.close()
     }

--- a/test/base.js
+++ b/test/base.js
@@ -280,6 +280,30 @@ test('Should be able to pass a custom server option to websocket-stream', (t) =>
   })
 })
 
+test('Should be able to pass clientTracking option in false to websocket-stream', (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  const options = {
+    clientTracking: false
+  }
+
+  fastify.register(fastifyWebsocket, { options })
+
+  fastify.get('/*', { websocket: true }, (connection, request) => {
+    connection.destroy()
+  })
+
+  fastify.listen(0, (err) => {
+    t.error(err)
+
+    fastify.close(err => {
+      t.error(err)
+    })
+  })
+})
+
 test('Should gracefully close with a connected client', (t) => {
   t.plan(6)
 


### PR DESCRIPTION
Hi, 

I found that if I have the websocket option `clientTracking` in false it throws an error during the `server.close()` because `server.clients` is undefined and the plugin expect always an iterable.

Checking for the server.clients undefined fix the issue.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
