### PR TITLE
revert dep major bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,4 @@ jobs:
       - uses: fastify/github-action-merge-dependabot@v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "ws": "^8.0.0"
+    "ws": "^7.5.4"
   }
 }


### PR DESCRIPTION
ws back to ^7

Ref: 
https://github.com/fastify/fastify-websocket/pull/137

Then we should release this as bugfix but @DRoet should revert the application's changes