### PR TITLE
Document installing @types/ws for TS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ Built upon [ws@8](https://www.npmjs.com/package/ws).
 
 ## Install
 
-```
+```shell
 npm install fastify-websocket --save
+# or 
+yarn install fastify-websocket
+```
+
+If you're a TypeScript user, this package has its own TypeScript types built in, but you will also need to install the types for the `ws` package:
+
+```shell
+npm install @types/ws --save-dev
+# or
+yarn install -D @types/ws
 ```
 
 ## Usage


### PR DESCRIPTION
Replaces #105 with some documentation. 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
