### PR TITLE
Update yarn add commands in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Built upon [ws@8](https://www.npmjs.com/package/ws).
 ```shell
 npm install fastify-websocket --save
 # or 
-yarn install fastify-websocket
+yarn add fastify-websocket
 ```
 
 If you're a TypeScript user, this package has its own TypeScript types built in, but you will also need to install the types for the `ws` package:
@@ -21,7 +21,7 @@ If you're a TypeScript user, this package has its own TypeScript types built in,
 ```shell
 npm install @types/ws --save-dev
 # or
-yarn install -D @types/ws
+yarn add -D @types/ws
 ```
 
 ## Usage


### PR DESCRIPTION
Yarn deprecated usage of `yarn install` in favor of `yarn add`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
