### PR TITLE
test: add back `preParsing` hook tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
-    "@types/ws": "^8.2.0",
-    "fastify": "^3.11.0",
+    "@types/ws": "^8.2.2",
+    "fastify": "^3.25.3",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "split2": "^4.1.0",
-    "standard": "^16.0.1",
-    "tap": "^15.0.2",
-    "tsd": "^0.19.0"
+    "standard": "^16.0.4",
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1"
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -7,7 +7,7 @@ const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
 
 test('Should run onRequest, preValidation, preHandler hooks', t => {
-  t.plan(6)
+  t.plan(7)
   const fastify = Fastify()
 
   t.teardown(() => fastify.close())
@@ -15,6 +15,7 @@ test('Should run onRequest, preValidation, preHandler hooks', t => {
   fastify.register(fastifyWebsocket)
 
   fastify.addHook('onRequest', async (request, reply) => t.ok('called', 'onRequest'))
+  fastify.addHook('preParsing', async (request, reply, payload) => t.ok('called', 'preParsing'))
   fastify.addHook('preValidation', async (request, reply) => t.ok('called', 'preValidation'))
   fastify.addHook('preHandler', async (request, reply) => t.ok('called', 'preHandler'))
 


### PR DESCRIPTION
Hello.

Following [this discussion](https://github.com/fastify/fastify/issues/3503), this PR aims to :
- add back `preParsing` hook tests
- upgrade package dependencies

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
