### PR TITLE
Ensure that hooks and error handlers can send standard HTTP replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,29 @@ fastify.get('/*', { websocket: true }, (connection, request) => {
   })
 })
 ```
+### Using hooks
+
+Routes registered with `fastify-websocket` respect the Fastify plugin encapsulation contexts, and so will run any hooks that have been registered. This means the same route hooks you might use for authentication or error handling of plain old HTTP handlers will apply to websocket handlers as well.
+
+```js
+fastify.addHook('preValidation', async (request, reply) => {
+  // check if the request is authenticated
+  if (!request.isAuthenticated()) {
+    await reply.code(401).send("not authenticated");
+  }
+})
+fastify.get('/', { websocket: true }, (connection, req) => {
+  // the connection will only be opened for authenticated incoming requests
+  connection.socket.on('message', message => {
+    // ...
+  })
+})
+```
 
 **NB**
 This plugin uses the same router as the `fastify` instance, this has a few implications to take into account:
-- Websocket route handlers follow the usual `fastify` request lifecycle.
+- Websocket route handlers follow the usual `fastify` request lifecycle, which means hooks, error handlers, and decorators all work the same way as other route handlers.
 - You can access the fastify server via `this` in your handlers
-- You can access the fastify request decorations via the `req` object your handlers
 - When using `fastify-websocket`, it needs to be registered before all routes in order to be able to intercept websocket connections to existing routes and close the connection on non-websocket routes.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function fastifyWebsocket (fastify, opts, next) {
       })
     } else {
       const rawResponse = new ServerResponse(rawRequest)
+      rawResponse.assignSocket(socket)
       fastify.routing(rawRequest, rawResponse)
     }
   })


### PR DESCRIPTION
This change fixes a bug in fastify-websocket where the `reply` object wouldn't actually send anything if it was asked to -- the only think you could do with it is hijack it. Before this change, if you tried to do reply.send or reply.code or what have you, those bytes would never make it out the client. I tested with browsers and with wsocat. The effect of this is that if someone is using an error handler to send errors as HTTP responses, or a validation handler that authenticates or something like that, those responses never make it to the client, but fastify considers the reply sent and is finished with it, leaving hanging sockets and broken expectations.

I think this is an accidental change introduced in #95 when we switched this library to start using fastify's routing and creating this reply object where we never quite set it up right. Now, we do a `response.assignSocket` with the socket given to us by the websocket server so that the response object can write to it.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
