### PR TITLE
Generic route options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,10 +5,12 @@ import * as fastify from 'fastify';
 import * as WebSocket from 'ws';
 import { Duplex } from 'stream';
 import { FastifyReply } from 'fastify/types/reply';
+import { RouteGenericInterface } from 'fastify/types/route';
 
-interface WebsocketRouteOptions {
-  wsHandler?: WebsocketHandler
+interface WebsocketRouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RequestGeneric extends RequestGenericInterface = RequestGenericInterface> {
+  wsHandler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric>;
 }
+
 declare module 'fastify' {
   interface RouteShorthandOptions<
     RawServer extends RawServerBase = RawServerDefault
@@ -33,13 +35,12 @@ declare module 'fastify' {
     ): FastifyInstance<RawServer, RawRequest, RawReply>;
   }
 
-  interface RouteOptions extends WebsocketRouteOptions {}
+  interface RouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>, RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault,SchemaCompiler = fastify.FastifySchema> extends WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric> {}
 }
 
 declare const websocketPlugin: FastifyPluginCallback<WebsocketPluginOptions>;
 
-interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, 'path'> {}
-
+interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, "path"> {}
 
 export type WebsocketHandler<
   RawServer extends RawServerBase = RawServerDefault,
@@ -60,6 +61,6 @@ export interface WebsocketPluginOptions {
   options?: WebSocketServerOptions;
 }
 
-export interface RouteOptions extends fastify.RouteOptions, WebsocketRouteOptions {}
+export interface RouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>, RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler = fastify.FastifySchema> extends fastify.RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>, WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric> {}
 
 export default websocketPlugin;

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,4 +1,5 @@
 import wsPlugin, { WebsocketHandler, SocketStream } from '../..';
+import type {IncomingMessage} from "http";
 import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface } from 'fastify';
 import { expectType } from 'tsd';
 import { Server } from 'ws';
@@ -19,12 +20,12 @@ app.register(wsPlugin, {
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });
 
-app.get('/websockets-via-inferrence', { websocket: true }, async function(connection, request) {
-    expectType<FastifyInstance>(this);
-    expectType<SocketStream>(connection);
-    expectType<Server>(app.websocketServer);
-    expectType<FastifyRequest<RequestGenericInterface>>(request)
-  });
+app.get('/websockets-via-inferrence', { websocket: true }, async function (connection, request) {
+  expectType<FastifyInstance>(this);
+  expectType<SocketStream>(connection);
+  expectType<Server>(app.websocketServer);
+  expectType<FastifyRequest<RequestGenericInterface>>(request)
+});
 
 const handler: WebsocketHandler = async (connection, request) => {
   expectType<SocketStream>(connection);
@@ -70,3 +71,33 @@ const augmentedRouteOptions: RouteOptions = {
   },
 };
 app.route(augmentedRouteOptions);
+
+
+app.get<{ Params: { foo: string }, Body: { bar: string }, Querystring: { search: string }, Headers: { auth: string } }>('/shorthand-explicit-types', {
+  websocket: true
+}, async (connection, request) => {
+  expectType<SocketStream>(connection);
+  expectType<{ foo: string }>(request.params);
+  expectType<{ bar: string }>(request.body);
+  expectType<{ search: string }>(request.query);
+  expectType< IncomingMessage['headers'] & { auth: string }>(request.headers);
+});
+
+
+app.route<{ Params: { foo: string }, Body: { bar: string }, Querystring: { search: string }, Headers: { auth: string } }>({
+  method: 'GET',
+  url: '/longhand-explicit-types',
+  handler: (request, _reply) => {
+    expectType<{ foo: string }>(request.params);
+    expectType<{ bar: string }>(request.body);
+    expectType<{ search: string }>(request.query);
+    expectType<IncomingMessage['headers'] & {  auth: string }>(request.headers);
+  },
+  wsHandler: (connection, request) => {
+    expectType<SocketStream>(connection);
+    expectType<{ foo: string }>(request.params);
+    expectType<{ bar: string }>(request.body);
+    expectType<{ search: string }>(request.query);
+    expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
+  },
+});

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -2,6 +2,7 @@ import wsPlugin, { WebsocketHandler, SocketStream } from '../..';
 import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface } from 'fastify';
 import { expectType } from 'tsd';
 import { Server } from 'ws';
+import { RouteGenericInterface } from 'fastify/types/route';
 
 const app: FastifyInstance = fastify();
 app.register(wsPlugin);
@@ -19,11 +20,11 @@ app.register(wsPlugin, {
 app.register(wsPlugin, { options: { perMessageDeflate: true } });
 
 app.get('/websockets-via-inferrence', { websocket: true }, async function(connection, request) {
-  expectType<FastifyInstance>(this);
-  expectType<SocketStream>(connection);
-  expectType<Server>(app.websocketServer);
-  expectType<FastifyRequest<RequestGenericInterface>>(request)
-});
+    expectType<FastifyInstance>(this);
+    expectType<SocketStream>(connection);
+    expectType<Server>(app.websocketServer);
+    expectType<FastifyRequest<RequestGenericInterface>>(request)
+  });
 
 const handler: WebsocketHandler = async (connection, request) => {
   expectType<SocketStream>(connection);
@@ -52,7 +53,7 @@ app.route({
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
-    expectType<FastifyRequest<RequestGenericInterface>>(request);
+    expectType<FastifyRequest<RouteGenericInterface>>(request);
   },
 });
 
@@ -65,7 +66,7 @@ const augmentedRouteOptions: RouteOptions = {
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
-    expectType<FastifyRequest<RequestGenericInterface>>(request)
+    expectType<FastifyRequest<RouteGenericInterface>>(request)
   },
 };
 app.route(augmentedRouteOptions);


### PR DESCRIPTION
This replaces and finishes the work started in #128 by adding some tests!

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
