### PR TITLE
Version bump ws from 8.0.0 to 8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
-    "@types/ws": "^8.2.2",
+    "@types/ws": "^8.5.1",
     "fastify": "^3.25.3",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "ws": "^8.0.0"
+    "ws": "^8.5.0"
   }
 }


### PR DESCRIPTION
Ref: https://github.com/fastify/fastify-websocket/issues/179

`npm run test` results:

```
> fastify-websocket@4.1.0 test
> npm run lint && npm run test:js && npm run test:ts


> fastify-websocket@4.1.0 lint
> standard | snazzy


> fastify-websocket@4.1.0 test:js
> npm run lint && npm run unit


> fastify-websocket@4.1.0 lint
> standard | snazzy


> fastify-websocket@4.1.0 unit
> tap --100 "test/*.js"

​ PASS ​ test/router.js 57 OK 150.247ms
​ PASS ​ test/base.js 43 OK 1s
​ PASS ​ test/hooks.js 31 OK 10s
​

                         
  🌈 SUMMARY RESULTS 🌈  
                         
​
Suites:   ​3 passed​, ​3 of 3 completed​
Asserts:  ​​​131 passed​, ​of 131​
​Time:​   ​10s​
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 index.js |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------

> fastify-websocket@4.1.0 test:ts
> tsd
```