### PR TITLE
Adding connectionOptions as a plugin option to enable Duplex options

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ fastify.listen(3000, err => {
 
 `fastify-websocket` accept these options for [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :
 
-- `objectMode` - Send each chunk on its own, and do not try to pack them in a single websocket frame.
 - `host` - The hostname where to bind the server.
 - `port` - The port where to bind the server.
 - `backlog` - The maximum length of the queue of pending connections.
@@ -257,6 +256,16 @@ _**NB** The `path` option from `ws` should not be provided since the routing is 
 
 _**NB** The `noServer` option from `ws` should not be provided since the point of fastify-websocket is to listen on the fastify server. If you want a custom server, you can use the `server` option, and if you want more control, you can use the `ws` library directly_
 
+You can also pass the following as `connectionOptions` for [createWebSocketStream](https://github.com/websockets/ws/blob/master/doc/ws.md#createwebsocketstreamwebsocket-options).
+
+- `allowHalfOpen` <boolean> If set to false, then the stream will automatically end the writable side when the readable side ends. Default: true.
+- `readable` <boolean> Sets whether the Duplex should be readable. Default: true.
+- `writable` <boolean> Sets whether the Duplex should be writable. Default: true.
+- `readableObjectMode` <boolean> Sets objectMode for readable side of the stream. Has no effect if objectMode is true. Default: false.
+- `readableHighWaterMark` <number> Sets highWaterMark for the readable side of the stream.
+- `writableHighWaterMark` <number> Sets highWaterMark for the writable side of the stream.
+
+[ws](https://github.com/websockets/ws) does not allow you to set `objectMode` or `writableObjectMode` to true
 ## Acknowledgements
 
 This project is kindly sponsored by [nearForm](https://nearform.com).

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { IncomingMessage, ServerResponse, Server } from 'http';
 import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance } from 'fastify';
 import * as fastify from 'fastify';
 import * as WebSocket from 'ws';
-import { Duplex } from 'stream';
+import { Duplex, DuplexOptions } from 'stream';
 import { FastifyReply } from 'fastify/types/reply';
 import { RouteGenericInterface } from 'fastify/types/route';
 
@@ -59,6 +59,7 @@ export interface SocketStream extends Duplex {
 export interface WebsocketPluginOptions {
   errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply) => void;
   options?: WebSocketServerOptions;
+  connectionOptions?: DuplexOptions;
 }
 
 export interface RouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>, RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler = fastify.FastifySchema> extends fastify.RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>, WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric> {}

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function fastifyWebsocket (fastify, opts, next) {
     wss.handleUpgrade(rawRequest, rawRequest[kWs], rawRequest[kWsHead], (socket) => {
       wss.emit('connection', socket, rawRequest)
 
-      const connection = WebSocket.createWebSocketStream(socket)
+      const connection = WebSocket.createWebSocketStream(socket, opts.connectionOptions)
       connection.socket = socket
 
       connection.socket.on('newListener', event => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Enabling connection options to solve a problem [described in this issue](https://github.com/fastify/fastify-websocket/issues/185).

`npm run test`
```
 PASS  test/base.js 46 OK 1s
 PASS  test/hooks.js 31 OK 10s
 PASS  test/router.js 57 OK 310.553ms



  🌈 SUMMARY RESULTS 🌈


Suites:   3 passed, 3 of 3 completed
Asserts:  134 passed, of 134
Time:   13s
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |
 index.js |     100 |      100 |     100 |     100 |
----------|---------|----------|---------|---------|-------------------
```