### PR TITLE
Add `request.ws` to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,10 @@ declare module 'fastify' {
     websocketServer: WebSocket.Server,
   }
 
+  interface FastifyReply {
+    ws: boolean
+  }
+
   interface RouteShorthandMethod<
     RawServer extends RawServerBase = RawServerDefault,
     RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module 'fastify' {
     websocketServer: WebSocket.Server,
   }
 
-  interface FastifyReply {
+  interface FastifyRequest {
     ws: boolean
   }
 

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -25,6 +25,7 @@ app.get('/websockets-via-inferrence', { websocket: true }, async function (conne
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
   expectType<FastifyRequest<RequestGenericInterface>>(request)
+  expectType<boolean>(request.ws);
 });
 
 const handler: WebsocketHandler = async (connection, request) => {
@@ -38,6 +39,7 @@ app.get('/websockets-via-annotated-const', { websocket: true }, handler);
 app.get('/not-specifed', async (request, reply) => {
   expectType<FastifyRequest>(request);
   expectType<FastifyReply>(reply)
+  expectType<boolean>(request.ws);
 });
 
 app.get('/not-websockets', { websocket: false }, async (request, reply) => {
@@ -51,10 +53,12 @@ app.route({
   handler: (request, reply) => {
     expectType<FastifyRequest>(request);
     expectType<FastifyReply>(reply);
+    expectType<boolean>(request.ws);
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
     expectType<FastifyRequest<RouteGenericInterface>>(request);
+    expectType<boolean>(request.ws);
   },
 });
 


### PR DESCRIPTION
Added this property in #163, but didn't add it to the typedefs, this finishes that.

Adds tests on top of and replaces #180 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
