### PR TITLE
feat: add message validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function fastifyWebsocket (fastify, opts, next) {
       wss.emit('connection', socket, rawRequest)
       const connection = WebSocket.createWebSocketStream(socket, opts.connectionOptions)
       socket.afterDuplex = true
-      socket.validator = request.context[kWebSocketSchema]
+      socket.validator = request && request.context ? request.context[kWebSocketSchema] : null
       socket.strict = opts.strictMode ? opts.strictMode : false
       connection.socket = socket
 
@@ -189,7 +189,7 @@ function fastifyWebsocket (fastify, opts, next) {
   const oldDefaultRoute = fastify.getDefaultRoute()
   fastify.setDefaultRoute(function (req, res) {
     if (req[kWs]) {
-      handleUpgrade(req, (connection) => {
+      handleUpgrade(req, null, (connection) => {
         noHandle.call(fastify, connection, req)
       })
     } else {

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function fastifyWebsocket (fastify, opts, next) {
     // Since we already handled the error, adding this listener prevents the ws
     // library from emitting the error and causing an uncaughtException
     // Reference: https://github.com/websockets/ws/blob/master/lib/stream.js#L35
-    conn.on('error', _ => {})
+    conn.on('error', _ => { })
     request.log.error(error)
     conn.destroy(error)
   }
@@ -217,13 +217,12 @@ class ValidateWebSocket extends WebSocket {
     return (message, isBinary) => {
       if (isBinary) return handler(message, isBinary)
       try {
-        if (!this.validator(JSON.parse(message.toString()))) {
-          if (this.strict) {
-            return this.close(1003, 'Unsupported payload')
-          } else {
-            return this.send(JSON.stringify(this.validator.errors))
-          }
+        const parsedInput = JSON.parse(message.toString())
+        if (this.validator(parsedInput)) return handler(parsedInput, false)
+        if (this.strict) {
+          return this.close(1003, 'Unsupported payload')
         }
+        return this.send(JSON.stringify(this.validator.errors))
       } catch (e) {
         if (this.strict) {
           return this.close(1003, 'Unsupported payload')
@@ -231,7 +230,6 @@ class ValidateWebSocket extends WebSocket {
           return this.send('Unsupported payload')
         }
       }
-      return handler(message, isBinary)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function fastifyWebsocket (fastify, opts, next) {
       wss.emit('connection', socket, rawRequest)
       const connection = WebSocket.createWebSocketStream(socket, opts.connectionOptions)
       socket.afterDuplex = true
-      socket.validator = request[kWebSocketSchema]
+      socket.validator = request.context[kWebSocketSchema]
       socket.strict = opts.strictMode ? opts.strictMode : false
       connection.socket = socket
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const kWsHead = Symbol('ws-head')
 
 function fastifyWebsocket (fastify, opts, next) {
   fastify.decorateRequest('ws', null)
-
+  
   let errorHandler = defaultErrorHandler
   if (opts.errorHandler) {
     if (typeof opts.errorHandler !== 'function') {
@@ -22,29 +22,29 @@ function fastifyWebsocket (fastify, opts, next) {
   if (opts.options && opts.options.noServer) {
     return next(new Error("fastify-websocket doesn't support the ws noServer option. If you want to create a websocket server detatched from fastify, use the ws library directly."))
   }
-
+  
   const wssOptions = Object.assign({ noServer: true }, opts.options)
-
+  
   if (wssOptions.path) {
     fastify.log.warn('ws server path option shouldn\'t be provided, use a route instead')
   }
-
+  
   // We always handle upgrading ourselves in this library so that we can dispatch through the fastify stack before actually upgrading
   // For this reason, we run the WebSocket.Server in noServer mode, and prevent the user from passing in a http.Server instance for it to attach to.
   // Usually, we listen to the upgrade event of the `fastify.server`, but we do still support this server option by just listening to upgrades on it if passed.
   const websocketListenServer = wssOptions.server || fastify.server
   delete wssOptions.server
-
+  
   const wss = new WebSocket.Server(wssOptions)
   fastify.decorate('websocketServer', wss)
-
+  
   websocketListenServer.on('upgrade', (rawRequest, socket, head) => {
     // Save a reference to the socket and then dispatch the request through the normal fastify router so that it will invoke hooks and then eventually a route handler that might upgrade the socket.
     rawRequest[kWs] = socket
     rawRequest[kWsHead] = head
-
+    
     if (closing) {
-      handleUpgrade(rawRequest, (connection) => {
+      handleUpgrade(rawRequest, request, (connection) => {
         connection.socket.close(1001)
       })
     } else {
@@ -53,12 +53,14 @@ function fastifyWebsocket (fastify, opts, next) {
       fastify.routing(rawRequest, rawResponse)
     }
   })
-
-  const handleUpgrade = (rawRequest, callback) => {
+  
+  const handleUpgrade = (rawRequest, request, callback) => {
     wss.handleUpgrade(rawRequest, rawRequest[kWs], rawRequest[kWsHead], (socket) => {
       wss.emit('connection', socket, rawRequest)
-
       const connection = WebSocket.createWebSocketStream(socket, opts.connectionOptions)
+      socket.afterDuplex = true
+      socket.validator = request.context.schema ? fastify.validatorCompiler({ schema: request.context.schema.body }) : null
+      socket.strict = opts.strictMode ? opts.strictMode : false
       connection.socket = socket
 
       connection.socket.on('newListener', event => {
@@ -66,11 +68,11 @@ function fastifyWebsocket (fastify, opts, next) {
           connection.resume()
         }
       })
-
+      
       callback(connection)
     })
   }
-
+  
   fastify.addHook('onRequest', (request, reply, done) => { // this adds req.ws to the Request object
     if (request.raw[kWs]) {
       request.ws = true
@@ -84,14 +86,14 @@ function fastifyWebsocket (fastify, opts, next) {
     if (request.raw[kWs]) {
       // Hijack reply to prevent fastify from sending the error after onError hooks are done running
       reply.hijack()
-      handleUpgrade(request.raw, connection => {
+      handleUpgrade(request.raw, request, connection => {
         // Handle the error
         errorHandler.call(this, error, connection, request, reply)
       })
     }
     done()
   })
-
+  
   fastify.addHook('onRoute', routeOptions => {
     let isWebsocketRoute = false
     let wsHandler = routeOptions.wsHandler
@@ -101,9 +103,9 @@ function fastifyWebsocket (fastify, opts, next) {
       if (routeOptions.method !== 'GET') {
         throw new Error('websocket handler can only be declared in GET method')
       }
-
+      
       isWebsocketRoute = true
-
+      
       if (routeOptions.websocket) {
         wsHandler = routeOptions.handler
         handler = function (request, reply) {
@@ -122,7 +124,7 @@ function fastifyWebsocket (fastify, opts, next) {
       // within the route handler, we check if there has been a connection upgrade by looking at request.raw[kWs]. we need to dispatch the normal HTTP handler if not, and hijack to dispatch the websocket handler if so
       if (request.raw[kWs]) {
         reply.hijack()
-        handleUpgrade(request.raw, connection => {
+        handleUpgrade(request.raw, request, connection => {
           let result
           try {
             if (isWebsocketRoute) {
@@ -145,9 +147,9 @@ function fastifyWebsocket (fastify, opts, next) {
   })
 
   fastify.addHook('onClose', close)
-
+  
   let closing = false
-
+  
   // Fastify is missing a pre-close event, or the ability to
   // add a hook before the server.close call. We need to resort
   // to monkeypatching for now.
@@ -158,19 +160,19 @@ function fastifyWebsocket (fastify, opts, next) {
     // Call oldClose first so that we stop listening. This ensures the
     // server.clients list will be up to date when we start closing below.
     oldClose.call(this, cb)
-
+    
     const server = fastify.websocketServer
     if (!server.clients) return
     for (const client of server.clients) {
       client.close()
     }
   }
-
+  
   function noHandle (connection, rawRequest) {
     this.log.info({ path: rawRequest.url }, 'closed incoming websocket connection for path with no websocket handler')
     connection.socket.close()
   }
-
+  
   function defaultErrorHandler (error, conn, request, reply) {
     // Before destroying the connection, we attach an error listener.
     // Since we already handled the error, adding this listener prevents the ws
@@ -191,7 +193,7 @@ function fastifyWebsocket (fastify, opts, next) {
       return oldDefaultRoute(req, res)
     }
   })
-
+  
   next()
 }
 
@@ -200,7 +202,48 @@ function close (fastify, done) {
   server.close(done)
 }
 
+class ValidateWebSocket extends WebSocket {
+  constructor (...args) {
+    super(...args)
+    this.afterDuplex = false
+    this.validator = null
+    this.strict = false
+  }
+
+  wrapValidation (handler) {
+    return (message, isBinary) => {
+      if (isBinary) return handler(message, isBinary)
+      try {
+        if (!this.validator(JSON.parse(message.toString()))) {
+          if (this.strict) {
+            return this.close(1003, 'Unsupported payload')
+          } else {
+            return this.send(JSON.stringify(this.validator.errors))
+          }
+        }
+      } catch (e) {
+        if (this.strict) {
+          return this.close(1003, 'Unsupported payload')
+        } else {
+          return this.send('Unsupported payload')
+        }
+      }
+      return handler(message, isBinary)
+    }
+  }
+
+  on (event, handler, options) {
+    if (!this.afterDuplex) return super.on(event, handler)
+    if (event === 'message') {
+      super.on(event, this.wrapValidation(handler), options)
+    } else {
+      super.on(event, handler, options)
+    }
+  }
+}
+
 module.exports = fp(fastifyWebsocket, {
   fastify: '>= 3.11.0',
   name: 'fastify-websocket'
 })
+module.exports.ValidateWebSocket = ValidateWebSocket

--- a/test/validation.js
+++ b/test/validation.js
@@ -1,0 +1,167 @@
+'use strict'
+
+const test = require('tap').test
+const Fastify = require('fastify')
+const fastifyWebsocket = require('..')
+const { ValidateWebSocket } = require('..')
+const WebSocket = require('ws')
+
+const testSchema = {
+  body: {
+    oneOf: [
+      { type: 'null' },
+      {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        },
+        required: [
+          'foo'
+        ],
+        additionalProperties: false
+      }
+    ]
+  }
+}
+const schemaError = [
+  { keyword: 'type', dataPath: '', schemaPath: '#/oneOf/0/type', params: { type: 'null' }, message: 'should be null' },
+  { keyword: 'required', dataPath: '', schemaPath: '#/oneOf/1/required', params: { missingProperty: 'foo' }, message: "should have required property 'foo'" },
+  { keyword: 'oneOf', dataPath: '', schemaPath: '#/oneOf', params: { passingSchemas: null }, message: 'should match exactly one schema in oneOf' }
+]
+
+test('Should validate a websocket message', (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket, { options: { WebSocket: ValidateWebSocket } })
+
+  fastify.get('/', { websocket: true, schema: testSchema }, (connection, request) => {
+    connection.socket.on('message', (message, isBinary) => {
+      t.equal(isBinary, false)
+      t.same(message, { foo: 'bar' })
+      t.teardown(connection.destroy.bind(connection))
+    })
+  })
+
+  fastify.listen(0, (err) => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/')
+    ws.on('open', e => {
+      ws.send(JSON.stringify({ foo: 'bar' }))
+    })
+  })
+})
+
+test('Should invalidate a websocket message strict mode True', (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket, { strictMode: true, options: { WebSocket: ValidateWebSocket } })
+
+  fastify.get('/', { websocket: true, schema: testSchema }, (connection, request) => {
+    connection.socket.on('error', err => {
+      t.error(err)
+    })
+    connection.socket.on('message', (message, isBinary) => {
+      t.error(message, 'Should not reach the event handler')
+    })
+  })
+  fastify.listen(0, (err) => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/')
+    ws.on('open', e => {
+      ws.send(JSON.stringify({ bar: 'foo' }))
+    })
+    ws.on('close', (code, reason) => {
+      t.equal(code, 1003)
+    })
+  })
+})
+
+test('Should invalidate a malformed websocket message strict mode True', (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket, { strictMode: true, options: { WebSocket: ValidateWebSocket } })
+
+  fastify.get('/', { websocket: true, schema: testSchema }, (connection, request) => {
+    connection.socket.on('error', err => {
+      t.error(err)
+    })
+    connection.socket.on('message', (message, isBinary) => {
+      t.error(message, 'Should not reach the event handler')
+    })
+  })
+  fastify.listen(0, (err) => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/')
+    ws.on('open', e => {
+      ws.send(JSON.stringify({ foo: 'bar' }) + '}')
+    })
+    ws.on('close', (code, reason) => {
+      t.equal(code, 1003)
+    })
+  })
+})
+
+test('Should invalidate a websocket message strict mode False', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket, { strictMode: false, options: { WebSocket: ValidateWebSocket } })
+
+  fastify.get('/', { websocket: true, schema: testSchema }, (connection, request) => {
+    connection.socket.on('error', err => {
+      t.error(err)
+    })
+    connection.socket.on('message', (message, isBinary) => {
+      t.error(message, 'Should not reach the event handler')
+    })
+  })
+  fastify.listen(0, (err) => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/')
+    ws.on('open', e => {
+      ws.send(JSON.stringify({ bar: 'foo' }))
+    })
+    ws.on('message', (data, isBinary) => {
+      t.equal(isBinary, false)
+      const jsonResponse = JSON.parse(data.toString())
+      t.same(jsonResponse, schemaError)
+    })
+  })
+})
+test('Should invalidate a malformed websocket message strict mode False', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify.register(fastifyWebsocket, { strictMode: false, options: { WebSocket: ValidateWebSocket } })
+
+  fastify.get('/', { websocket: true, schema: testSchema }, (connection, request) => {
+    connection.socket.on('error', err => {
+      t.error(err)
+    })
+    connection.socket.on('message', (message, isBinary) => {
+      t.error(message, 'Should not reach the event handler')
+    })
+  })
+  fastify.listen(0, (err) => {
+    t.error(err)
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/')
+    ws.on('open', e => {
+      ws.send(JSON.stringify({ foo: 'bar' }) + '}')
+    })
+    ws.on('message', (data, isBinary) => {
+      t.equal(isBinary, false)
+      t.equal(data.toString(), 'Unsupported payload')
+    })
+  })
+})


### PR DESCRIPTION
fix: https://github.com/fastify/fastify-websocket/issues/190

First implementation. Basically the use would be:
```js

const Fastify = require('fastify')
const fastifyWebsocket = require('.')
const { ValidateWebSocket } = require('.')
const fastify = Fastify({ logger: true })

fastify.register(fastifyWebsocket, { options: { WebSocket: ValidateWebSocket } })

fastify.get('/', {
    websocket: true,
    schema: {
        body: {
            oneOf:
                [
                    { type: 'null' }, // This is required because of the upgrade
                    {
                        type: 'object',
                        properties: {
                            foo: {
                                type: 'string'
                            }
                        },
                        required: [
                            'foo'
                        ],
                        additionalProperties: false
                    }
                ]

        }
    }
}, (connection, request) => {
    connection.socket.on('message', () => {
        connection.socket.send('ok')
    })
})

fastify.listen(3000, '0.0.0.0', (err) => {
})

```

This also adds 2 way of handling the validation errors with the `strictMode`. If is set to `true` it closes the connection with a `1003` code, otherwise it sends the validator errors in the payload.

Kudos to @climba03003 who helped a lot

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
