### PR TITLE
Added SchemaCompiler, TypeProvider, and Logger to types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,21 @@
 /// <reference types="node" />
 import { IncomingMessage, ServerResponse, Server } from 'http';
-import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance} from 'fastify';
+import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance, FastifySchema, FastifyTypeProvider, FastifyTypeProviderDefault, FastifyBaseLogger } from 'fastify';
 import * as fastify from 'fastify';
 import * as WebSocket from 'ws';
 import { Duplex, DuplexOptions } from 'stream';
 import { FastifyReply } from 'fastify/types/reply';
 import { RouteGenericInterface } from 'fastify/types/route';
 
-interface WebsocketRouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RequestGeneric extends RequestGenericInterface = RequestGenericInterface> {
-  wsHandler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric>;
+interface WebsocketRouteOptions<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
+  SchemaCompiler extends FastifySchema = FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
+> {
+  wsHandler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, SchemaCompiler, TypeProvider, Logger>;
 }
 
 declare module 'fastify' {
@@ -31,29 +38,42 @@ declare module 'fastify' {
     RawServer extends RawServerBase = RawServerDefault,
     RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
     RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+    TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
   > {
-    <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault>(
+    <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
       path: string,
       opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> & { websocket: true }, // this creates an overload that only applies these different types if the handler is for websockets
-      handler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric>
-    ): FastifyInstance<RawServer, RawRequest, RawReply>;
+      handler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, SchemaCompiler, TypeProvider, Logger>
+    ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   }
 
-  interface RouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>, RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault,SchemaCompiler = fastify.FastifySchema> extends WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric> {}
+  interface RouteOptions<
+    RawServer extends RawServerBase = RawServerDefault,
+    RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+    RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+    RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+    ContextConfig = ContextConfigDefault,
+    SchemaCompiler = fastify.FastifySchema,
+    TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+    Logger extends FastifyBaseLogger = FastifyBaseLogger
+  > extends WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric, SchemaCompiler, TypeProvider, Logger> { }
 }
 
 declare const websocketPlugin: FastifyPluginCallback<WebsocketPluginOptions>;
 
-interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, "path"> {}
+interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, "path"> { }
 
 export type WebsocketHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
-  RequestGeneric extends RequestGenericInterface = RequestGenericInterface
+  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
+  SchemaCompiler extends FastifySchema = FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
 > = (
   this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   connection: SocketStream,
-  request: FastifyRequest<RequestGeneric, RawServer, RawRequest>,
+  request: FastifyRequest<RequestGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, Logger>,
 ) => void | Promise<any>;
 
 export interface SocketStream extends Duplex {
@@ -66,6 +86,15 @@ export interface WebsocketPluginOptions {
   connectionOptions?: DuplexOptions;
 }
 
-export interface RouteOptions<RawServer extends RawServerBase = RawServerDefault, RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>, RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>, RouteGeneric extends RouteGenericInterface = RouteGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends fastify.FastifySchema = fastify.FastifySchema> extends fastify.RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler>, WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric> {}
+export interface RouteOptions<
+  RawServer extends RawServerBase = RawServerDefault,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  ContextConfig = ContextConfigDefault,
+  SchemaCompiler extends fastify.FastifySchema = fastify.FastifySchema,
+  TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger
+> extends fastify.RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>, WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric, SchemaCompiler, TypeProvider, Logger> { }
 
 export default websocketPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,11 +11,12 @@ interface WebsocketRouteOptions<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
+  ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
   Logger extends FastifyBaseLogger = FastifyBaseLogger
 > {
-  wsHandler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, SchemaCompiler, TypeProvider, Logger>;
+  wsHandler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>;
 }
 
 declare module 'fastify' {
@@ -43,7 +44,7 @@ declare module 'fastify' {
     <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
       path: string,
       opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> & { websocket: true }, // this creates an overload that only applies these different types if the handler is for websockets
-      handler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, SchemaCompiler, TypeProvider, Logger>
+      handler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>
     ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   }
 
@@ -56,7 +57,7 @@ declare module 'fastify' {
     SchemaCompiler = fastify.FastifySchema,
     TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
     Logger extends FastifyBaseLogger = FastifyBaseLogger
-  > extends WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric, SchemaCompiler, TypeProvider, Logger> { }
+  > extends WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> { }
 }
 
 declare const websocketPlugin: FastifyPluginCallback<WebsocketPluginOptions>;
@@ -67,13 +68,14 @@ export type WebsocketHandler<
   RawServer extends RawServerBase = RawServerDefault,
   RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
+  ContextConfig = ContextConfigDefault,
   SchemaCompiler extends FastifySchema = FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
   Logger extends FastifyBaseLogger = FastifyBaseLogger
 > = (
   this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
   connection: SocketStream,
-  request: FastifyRequest<RequestGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, Logger>,
+  request: FastifyRequest<RequestGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>
 ) => void | Promise<any>;
 
 export interface SocketStream extends Duplex {
@@ -95,6 +97,6 @@ export interface RouteOptions<
   SchemaCompiler extends fastify.FastifySchema = fastify.FastifySchema,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault,
   Logger extends FastifyBaseLogger = FastifyBaseLogger
-> extends fastify.RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>, WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric, SchemaCompiler, TypeProvider, Logger> { }
+> extends fastify.RouteOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>, WebsocketRouteOptions<RawServer, RawRequest, RouteGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> { }
 
 export default websocketPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module 'fastify' {
   > {
     <RequestGeneric extends RequestGenericInterface = RequestGenericInterface, ContextConfig = ContextConfigDefault, SchemaCompiler extends FastifySchema = FastifySchema, Logger extends FastifyBaseLogger = FastifyBaseLogger>(
       path: string,
-      opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> & { websocket: true }, // this creates an overload that only applies these different types if the handler is for websockets
+      opts: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger> & { websocket: true }, // this creates an overload that only applies these different types if the handler is for websockets
       handler?: WebsocketHandler<RawServer, RawRequest, RequestGeneric, SchemaCompiler, TypeProvider, Logger>
     ): FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider>;
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   "homepage": "https://github.com/fastify/fastify-websocket#readme",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
+    "@fastify/type-provider-typebox": "^2.3.0",
+    "@sinclair/typebox": "^0.24.44",
     "@types/ws": "^8.2.2",
     "fastify": "^4.0.0-rc.2",
     "snazzy": "^9.0.0",


### PR DESCRIPTION
https://github.com/fastify/fastify-websocket/issues/213

Fixed TypeProvider typings in its WebsocketHandler by adding SchemaCompiler, TypeProvider, and Logger.  Attempted to mirror the style used in fastify route.d.ts.
