### PR TITLE
fix/ws-error-handler - Handle WebSocket errors to avoid Node.js crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ function fastifyWebsocket (fastify, opts, next) {
       const connection = WebSocket.createWebSocketStream(socket, opts.connectionOptions)
       connection.socket = socket
 
+      connection.on('error', (error) => {
+        fastify.log.error(error)
+      })
+
       connection.socket.on('newListener', event => {
         if (event === 'message') {
           connection.resume()


### PR DESCRIPTION
Some safari browsers are buggy and set some bits without negotiating them with the server.
This cause the server crash with:
```
code: "WS_ERR_UNEXPECTED_RSV_2_3"
message: "Invalid WebSocket frame: RSV2 and RSV3 must be clear"
stack: "RangeError: Invalid WebSocket frame: RSV2 and RSV3 must be clear
    at Receiver.getInfo (/app/node_modules/ws/lib/receiver.js:176:14)
    at Receiver.startLoop (/app/node_modules/ws/lib/receiver.js:136:22)
    at Receiver._write (/app/node_modules/ws/lib/receiver.js:83:10)
    at writeOrBuffer (node:internal/streams/writable:392:12)
    at _write (node:internal/streams/writable:333:10)
    at Writable.write (node:internal/streams/writable:337:10)
    at Socket.socketOnData (/app/node_modules/ws/lib/websocket.js:1272:35)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)"
type: "RangeError"
```

Related issue on mercurius: [https://github.com/mercurius-js/mercurius/issues/908](https://github.com/mercurius-js/mercurius/issues/908).

#### Checklist

- [ x ] run `npm run test` and `npm run benchmark`
- [ x ] tests and/or benchmarks are included
- [ x ] documentation is changed or added
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
