### PR TITLE
Remove override of the default route

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,17 +182,6 @@ function fastifyWebsocket (fastify, opts, next) {
     conn.destroy(error)
   }
 
-  const oldDefaultRoute = fastify.getDefaultRoute()
-  fastify.setDefaultRoute(function (req, res) {
-    if (req[kWs]) {
-      handleUpgrade(req, (connection) => {
-        noHandle.call(fastify, connection, req)
-      })
-    } else {
-      return oldDefaultRoute(req, res)
-    }
-  })
-
   next()
 }
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -457,7 +457,7 @@ test('Should open on registered path', t => {
 
   fastify.listen({ port: 0 }, err => {
     t.error(err)
-    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo/')
+    const ws = new WebSocket('ws://localhost:' + (fastify.server.address()).port + '/echo')
     ws.on('open', () => {
       t.pass()
       client.end()


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

Just so you know, the change in the test is unrelated. That test checked if we trying to connect to a known route, and `/echo/` was not registered, only `/echo` was.

Fixes #236.
Fixes https://github.com/platformatic/platformatic/issues/575.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
