### PR TITLE
Add preClose opt + merge close and preClose hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Note that `preClose` is responsible for closing all connections and closing the 
 const fastify = require('fastify')()
 
 fastify.register(require('@fastify/websocket'), {
-  preClose: (done) => {
+  preClose: (done) => { // Note: can also use async style, without done-callback
     const server = this.websocketServer
 
     for (const connection of server.clients) {

--- a/README.md
+++ b/README.md
@@ -233,6 +233,29 @@ fastify.listen({ port: 3000 }, err => {
 ```
 
 Note: Fastify's `onError` and error handlers registered by `setErrorHandler` will still be called for errors encountered *before* the websocket connection is established. This means errors thrown by `onRequest` hooks, `preValidation` handlers, and hooks registered by plugins will use the normal error handling mechanisms in Fastify. Once the websocket is established and your websocket route handler is called, `fastify-websocket`'s `errorHandler` takes over.
+
+### Custom preClose hook:
+
+By default, all ws connections are closed when the server closes. If you wish to modify this behaviour, you can pass your own `preClose` function.
+
+Note that `preClose` is responsible for closing all connections and closing the websocket server.
+
+```js
+const fastify = require('fastify')()
+
+fastify.register(require('@fastify/websocket'), {
+  preClose: (done) => {
+    const server = this.websocketServer
+
+    for (const connection of server.clients) {
+      connection.close(1001, 'WS server is going offline in custom manner, sending a code + message')
+    }
+
+    server.close(done)
+  }
+})
+```
+
 ## Options
 
 `@fastify/websocket` accept these options for [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :

--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@ function fastifyWebsocket (fastify, opts, next) {
   }
 
   let preClose = defaultPreClose
-  if (opts.options && opts.options.preClose) {
-    if (typeof opts.options.preClose !== 'function') {
+  if (opts && opts.preClose) {
+    if (typeof opts.preClose !== 'function') {
       return next(new Error('invalid preClose function'))
     }
 
-    preClose = opts.options.preClose
+    preClose = opts.preClose
   }
 
   if (opts.options && opts.options.noServer) {

--- a/index.js
+++ b/index.js
@@ -152,18 +152,10 @@ function fastifyWebsocket (fastify, opts, next) {
     }
   })
 
-  fastify.addHook('onClose', close)
-
   // Fastify is missing a pre-close event, or the ability to
   // add a hook before the server.close call. We need to resort
   // to monkeypatching for now.
-
   fastify.addHook('preClose', preClose)
-
-  function close (fastify, done) {
-    const server = fastify.websocketServer
-    server.close(done)
-  }
 
   function noHandle (connection, rawRequest) {
     this.log.info({ path: rawRequest.url }, 'closed incoming websocket connection for path with no websocket handler')
@@ -178,6 +170,9 @@ function fastifyWebsocket (fastify, opts, next) {
       }
     }
     fastify.server.removeListener('upgrade', onUpgrade)
+
+    server.close(done)
+
     done()
   }
 

--- a/index.js
+++ b/index.js
@@ -157,11 +157,6 @@ function fastifyWebsocket (fastify, opts, next) {
   // to monkeypatching for now.
   fastify.addHook('preClose', preClose)
 
-  function noHandle (connection, rawRequest) {
-    this.log.info({ path: rawRequest.url }, 'closed incoming websocket connection for path with no websocket handler')
-    connection.socket.close()
-  }
-
   function defaultPreClose (done) {
     const server = this.websocketServer
     if (server.clients) {
@@ -174,6 +169,11 @@ function fastifyWebsocket (fastify, opts, next) {
     server.close(done)
 
     done()
+  }
+
+  function noHandle (connection, rawRequest) {
+    this.log.info({ path: rawRequest.url }, 'closed incoming websocket connection for path with no websocket handler')
+    connection.socket.close()
   }
 
   function defaultErrorHandler (error, conn, request) {

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -351,6 +351,78 @@ test('Should be able to pass custom connectionOptions to createWebSocketStream',
   await p
 })
 
+test('Should be able to pass preClose option to override default', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  const options = {
+    preClose: (done) => {
+      t.pass('Custom preclose successfully called')
+
+      for (const connection of fastify.websocketServer.clients) {
+        connection.close()
+      }
+      done()
+    }
+  }
+
+  await fastify.register(fastifyWebsocket, { options })
+
+  fastify.get('/', { websocket: true }, (connection) => {
+    connection.setEncoding('utf8')
+    t.teardown(() => connection.destroy())
+
+    connection.once('data', (chunk) => {
+      t.equal(chunk, 'hello server')
+      connection.write('hello client')
+      connection.end()
+    })
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
+  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+  t.teardown(() => client.destroy())
+
+  client.setEncoding('utf8')
+  client.write('hello server')
+
+  const [chunk] = await once(client, 'data')
+  t.equal(chunk, 'hello client')
+  client.end()
+
+  await fastify.close()
+})
+
+test('Should fail if custom preClose is not a function', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  const options = {
+    preClose: 'Not a function'
+  }
+
+  try {
+    await fastify.register(fastifyWebsocket, { options })
+  } catch (err) {
+    t.equal(err.message, 'invalid preClose function')
+  }
+
+  fastify.get('/', { websocket: true }, (connection) => {
+    t.teardown(() => connection.destroy())
+  })
+
+  try {
+    await fastify.listen({ port: 0 })
+  } catch (err) {
+    t.equal(err.message, 'invalid preClose function')
+  }
+})
+
 test('Should gracefully close with a connected client', async (t) => {
   t.plan(2)
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -356,18 +356,16 @@ test('Should be able to pass preClose option to override default', async (t) => 
 
   const fastify = Fastify()
 
-  const options = {
-    preClose: (done) => {
-      t.pass('Custom preclose successfully called')
+  const preClose = (done) => {
+    t.pass('Custom preclose successfully called')
 
-      for (const connection of fastify.websocketServer.clients) {
-        connection.close()
-      }
-      done()
+    for (const connection of fastify.websocketServer.clients) {
+      connection.close()
     }
+    done()
   }
 
-  await fastify.register(fastifyWebsocket, { options })
+  await fastify.register(fastifyWebsocket, { preClose })
 
   fastify.get('/', { websocket: true }, (connection) => {
     connection.setEncoding('utf8')
@@ -402,12 +400,10 @@ test('Should fail if custom preClose is not a function', async (t) => {
   const fastify = Fastify()
   t.teardown(() => fastify.close())
 
-  const options = {
-    preClose: 'Not a function'
-  }
+  const preClose = 'Not a function'
 
   try {
-    await fastify.register(fastifyWebsocket, { options })
+    await fastify.register(fastifyWebsocket, { preClose })
   } catch (err) {
     t.equal(err.message, 'invalid preClose function')
   }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -5,7 +5,7 @@ const net = require('net')
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
-const split = require('split2')
+// const split = require('split2')
 
 test('Should run onRequest, preValidation, preHandler hooks', t => {
   t.plan(7)
@@ -361,6 +361,8 @@ test('Should not hijack reply for an normal request to a websocket route that is
   })
 })
 
+// Broken since this commit: https://github.com/fastify/fastify-websocket/commit/ec0e7aef272b869607627754ae3c978d13d8259b
+/*
 test('Should not hijack reply for an WS request to a WS route that gets sent a normal HTTP response in a hook', t => {
   t.plan(6)
   const stream = split(JSON.parse)
@@ -392,3 +394,4 @@ test('Should not hijack reply for an WS request to a WS route that gets sent a n
     })
   })
 })
+*/

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -362,7 +362,7 @@ test('Should not hijack reply for an normal request to a websocket route that is
 })
 
 test('Should not hijack reply for an WS request to a WS route that gets sent a normal HTTP response in a hook', t => {
-  t.plan(5)
+  t.plan(6)
   const stream = split(JSON.parse)
   const fastify = Fastify({ logger: { stream } })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -5,7 +5,7 @@ const net = require('net')
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
-// const split = require('split2')
+const split = require('split2')
 
 test('Should run onRequest, preValidation, preHandler hooks', t => {
   t.plan(7)
@@ -361,10 +361,8 @@ test('Should not hijack reply for an normal request to a websocket route that is
   })
 })
 
-// Broken since this commit: https://github.com/fastify/fastify-websocket/commit/ec0e7aef272b869607627754ae3c978d13d8259b
-/*
 test('Should not hijack reply for an WS request to a WS route that gets sent a normal HTTP response in a hook', t => {
-  t.plan(6)
+  t.plan(5)
   const stream = split(JSON.parse)
   const fastify = Fastify({ logger: { stream } })
 
@@ -394,4 +392,3 @@ test('Should not hijack reply for an WS request to a WS route that gets sent a n
     })
   })
 })
-*/

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ import * as fastify from 'fastify';
 import WebSocket from 'ws';
 import { Duplex, DuplexOptions } from 'stream';
 import { FastifyReply } from 'fastify/types/reply';
+import { preCloseHookHandler, preCloseAsyncHookHandler } from 'fastify/types/hooks';
 import { RouteGenericInterface } from 'fastify/types/route';
 
 interface WebsocketRouteOptions<
@@ -88,6 +89,7 @@ declare namespace fastifyWebsocket {
     errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply) => void;
     options?: WebSocketServerOptions;
     connectionOptions?: DuplexOptions;
+    preClose?: preCloseHookHandler | preCloseAsyncHookHandler;
   }
 
   export interface RouteOptions<

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -22,6 +22,8 @@ app.register(wsPlugin, {
   }
 });
 app.register(wsPlugin, { options: { perMessageDeflate: true } });
+app.register(wsPlugin, { preClose: function syncPreclose() {} });
+app.register(wsPlugin, { preClose: async function asyncPreclose(){} });
 
 app.get('/websockets-via-inferrence', { websocket: true }, async function (connection, request) {
   expectType<FastifyInstance>(this);


### PR DESCRIPTION
<strike>WARNING: current master has a failing test. To get past the precommit script, I had to comment it out. Let me know if you would like a different approach.</strike>
The test in question (`Should not hijack reply for an WS request to a WS route that gets sent a normal HTTP response in a hook`) is failing on my local machine, where only 5 of the 6 planned verifications happen, but passes fine in the CI, so it does not affect this PR

All other tests (including the newly added ones) pass.

Note: I did not find a benchmark script to run as per the instructions below, so I did not check that box.

Fixes https://github.com/fastify/fastify-websocket/issues/260



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [X ] tests and/or benchmarks are included
- [ X] documentation is changed or added
- [ X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
