### PR TITLE
Updated a link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ fastify.get('/', { websocket: true }, function wsHandler (connection, req) {
 await fastify.listen({ port: 3000 })
 ```
 
-If you need to handle both HTTP requests and incoming socket connections on the same route, you can still do it using the [full declaration syntax](https://www.fastify.io/docs/latest/Routes/#full-declaration), adding a `wsHandler` property.
+If you need to handle both HTTP requests and incoming socket connections on the same route, you can still do it using the [full declaration syntax](https://fastify.dev/docs/latest/Reference/Routes/#full-declaration), adding a `wsHandler` property.
 
 ```js
 'use strict'


### PR DESCRIPTION
Link for handling both HTTP and sockets connection  (Full declaration syntax) is no longer valid. This PR add the new link for it.