### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServerResponse } = require('http')
+const { ServerResponse } = require('node:http')
 const fp = require('fastify-plugin')
 const WebSocket = require('ws')
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,17 +1,17 @@
 'use strict'
 
-const http = require('http')
-const util = require('util')
+const http = require('node:http')
+const util = require('node:util')
 const split = require('split2')
 const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
-const { once, on } = require('events')
+const { once, on } = require('node:events')
 let timersPromises
 
 try {
-  timersPromises = require('timers/promises')
+  timersPromises = require('node:timers/promises')
 } catch {}
 
 test('Should expose a websocket', async (t) => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tap').test
-const net = require('net')
+const net = require('node:net')
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const net = require('net')
+const net = require('node:net')
 const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyWebsocket = require('..')
 const WebSocket = require('ws')
-const get = require('http').get
+const get = require('node:http').get
 
 test('Should expose a websocket on prefixed route', t => {
   t.plan(4)


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
