### PR TITLE
Add #injectWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ test('connect to /', async (t) => {
 - Websocket need to be closed manually at the end of each test.
 - `fastify.ready()` needs to be awaited to ensure that fastify has been decorated.
 - You need to register the event listener before sending the message if you need to process server response.
-- It's possible to use 
+
 ## Options
 
 `@fastify/websocket` accept these options for [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ fastify.register(require('@fastify/websocket'), {
 Testing the ws handler can be quite tricky, luckily `fastify-websocket` decorates fastify instance with `injectWS`.
 It allows to test easily a websocket endpoint.
 
+The signature of injectWS is the following: `([path], [upgradeContext])`.
+
 #### App.js
 
 ```js
@@ -272,7 +274,14 @@ const FastifyWebSocket = require('@fastify/websocket')
 const App = Fastify()
 
 App.register(FastifyWebSocket);
+
 App.register(async function(fastify) {
+  fastify.addHook('preValidation', async (request, reply) => {
+    if (request.headers['api-key'] !== 'some-random-key') {
+      return reply.code(401).send()
+    }
+  })
+
   fastify.get('/', { websocket: true }, (connection) => {
     connection.socket.on('message', message => {
       connection.socket.send('hi from server')
@@ -299,7 +308,7 @@ test('connect to /', async (t) => {
   fastify.register(App)
   t.teardown(fastify.close.bind(fastify))
 
-  const ws = await fastify.injectWS('/')
+  const ws = await fastify.injectWS('/', {headers: { "api-key" : "some-random-key" }})
   let resolve;
   const promise = new Promise(r => { resolve = r })
 
@@ -318,7 +327,7 @@ test('connect to /', async (t) => {
 - Websocket need to be closed manually at the end of each test.
 - `fastify.ready()` needs to be awaited to ensure that fastify has been decorated.
 - You need to register the event listener before sending the message if you need to process server response.
-
+- It's possible to use 
 ## Options
 
 `@fastify/websocket` accept these options for [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :

--- a/README.md
+++ b/README.md
@@ -256,6 +256,69 @@ fastify.register(require('@fastify/websocket'), {
 })
 ```
 
+### Testing
+
+Testing the ws handler can be quite tricky, luckily `fastify-websocket` decorates fastify instance with `injectWS`.
+It allows to test easily a websocket endpoint.
+
+#### App.js
+
+```js
+'use strict'
+
+const Fastify = require('fastify')
+const FastifyWebSocket = require('@fastify/websocket')
+
+const App = Fastify()
+
+App.register(FastifyWebSocket);
+App.register(async function(fastify) {
+  fastify.get('/', { websocket: true }, (connection) => {
+    connection.socket.on('message', message => {
+      connection.socket.send('hi from server')
+    })
+  })
+})
+
+module.exports = App 
+```
+
+#### App.test.js
+
+```js
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const App = require('./app.js')
+
+test('connect to /', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  fastify.register(App)
+  t.teardown(fastify.close.bind(fastify))
+
+  const ws = await fastify.injectWS('/')
+  let resolve;
+  const promise = new Promise(r => { resolve = r })
+
+  ws.on('message', (data) => {
+    resolve(data.toString());
+  })
+  ws.send('hi from client')
+
+  t.assert(await promise, 'hi from server')
+  // Remember to close the ws at the end
+  ws.terminate()
+})
+```
+
+#### Things to know
+- Websocket need to be closed manually at the end of each test.
+- `fastify.ready()` needs to be awaited to ensure that fastify has been decorated.
+- You need to register the event listener before sending the message if you need to process server response.
+
 ## Options
 
 `@fastify/websocket` accept these options for [`ws`](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) :

--- a/index.js
+++ b/index.js
@@ -74,8 +74,8 @@ function fastifyWebsocket (fastify, opts, next) {
         ws.setSocket(clientStream, head, { maxPayload: 0 })
       } else {
         clientStream.removeListener('data', onData)
-
-        reject(new Error('Websocket injection failed'))
+        const statusCode = Number(chunk.toString().match(/HTTP\/1.1 (\d+)/)[1])
+        reject(new Error('Unexpected server response: ' + statusCode))
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const kWsHead = Symbol('ws-head')
 
 function fastifyWebsocket (fastify, opts, next) {
   fastify.decorateRequest('ws', null)
-  const injectedWs = []
 
   let errorHandler = defaultErrorHandler
   if (opts.errorHandler) {
@@ -75,7 +74,6 @@ function fastifyWebsocket (fastify, opts, next) {
       if (chunk.toString().includes('HTTP/1.1 101 Switching Protocols')) {
         ws._isServer = false
         ws.setSocket(clientStream, head, { maxPayload: 0 })
-        injectedWs.push(ws)
       }
     }
 
@@ -217,14 +215,6 @@ function fastifyWebsocket (fastify, opts, next) {
     if (server.clients) {
       for (const client of server.clients) {
         client.close()
-      }
-    }
-
-    // Close all the mocked socket used by injectWS
-    // This is needed to avoid test hanging
-    if (injectedWs.length) {
-      for (const ws of injectedWs) {
-        ws.terminate()
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function fastifyWebsocket (fastify, opts, next) {
   const wss = new WebSocket.Server(wssOptions)
   fastify.decorate('websocketServer', wss)
 
-  async function injectWS (path = '/') {
+  async function injectWS (path = '/', upgradeContext = {}) {
     const server2Client = new PassThrough()
     const client2Server = new PassThrough()
 
@@ -80,8 +80,10 @@ function fastifyWebsocket (fastify, opts, next) {
     clientStream.on('data', onData)
 
     const req = {
+      ...upgradeContext,
       method: 'GET',
       headers: {
+        ...upgradeContext.headers,
         connection: 'upgrade',
         upgrade: 'websocket',
         'sec-websocket-version': 13,

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function fastifyWebsocket (fastify, opts, next) {
     const serverStream = new Duplexify(server2Client, client2Server)
     const clientStream = new Duplexify(client2Server, server2Client)
 
-    const ws = new WebSocket(null, { isServer: false })
+    const ws = new WebSocket(null, undefined, { isServer: false })
     const head = Buffer.from([])
 
     let resolve, reject

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "duplexify": "^4.1.2",
     "fastify-plugin": "^4.0.0",
-    "mock-websocket": "^0.0.7",
     "ws": "^8.0.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "tsd": "^0.29.0"
   },
   "dependencies": {
+    "duplexify": "^4.1.2",
     "fastify-plugin": "^4.0.0",
     "ws": "^8.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "duplexify": "^4.1.2",
     "fastify-plugin": "^4.0.0",
+    "mock-websocket": "^0.0.7",
     "ws": "^8.0.0"
   },
   "publishConfig": {

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -86,3 +86,32 @@ test('routes correctly the message between two routes', async (t) => {
   t.same(await promise, message)
   ws.terminate()
 })
+
+test('use the upgrade context to upgrade if there is some hook', async (t) => {
+  const fastify = buildFastify(t)
+  const message = 'hi from client'
+
+  let _resolve
+  const promise = new Promise((resolve) => { _resolve = resolve })
+
+  fastify.register(
+    async function (instance) {
+      instance.addHook('preValidation', async (request, reply) => {
+        if (request.headers['api-key'] !== 'some-random-key') {
+          return reply.code(401).send()
+        }
+      })
+
+      instance.get('/', { websocket: true }, function (conn) {
+        conn.once('data', chunk => {
+          _resolve(chunk.toString())
+        })
+      })
+    })
+
+  await fastify.ready()
+  const ws = await fastify.injectWS('/', { headers: { 'api-key': 'some-random-key' } })
+  ws.send(message)
+  t.same(await promise, message)
+  ws.terminate()
+})

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const fastifyWebsocket = require('..')
+
+function buildFastify (t) {
+  const fastify = Fastify()
+  t.teardown(() => { fastify.close() })
+  fastify.register(fastifyWebsocket)
+  return fastify
+}
+
+test('routes correctly the message', async (t) => {
+  const fastify = buildFastify(t)
+  const message = 'hi from client'
+
+  let _resolve
+  const promise = new Promise((resolve) => { _resolve = resolve })
+
+  fastify.register(
+    async function (instance) {
+      instance.get('/ws', { websocket: true }, function (conn) {
+        conn.once('data', chunk => {
+          _resolve(chunk.toString())
+        })
+      })
+    })
+
+  await fastify.ready()
+  const ws = await fastify.injectWS('/ws')
+  ws.send(message)
+  t.same(await promise, message)
+})
+
+test('redirect on / if no path specified', async (t) => {
+  const fastify = buildFastify(t)
+  const message = 'hi from client'
+
+  let _resolve
+  const promise = new Promise((resolve) => { _resolve = resolve })
+
+  fastify.register(
+    async function (instance) {
+      instance.get('/', { websocket: true }, function (conn) {
+        conn.once('data', chunk => {
+          _resolve(chunk.toString())
+        })
+      })
+    })
+
+  await fastify.ready()
+  const ws = await fastify.injectWS()
+  ws.send(message)
+  t.same(await promise, message)
+})
+
+test('routes correctly the message between two routes', async (t) => {
+  const fastify = buildFastify(t)
+  const message = 'hi from client'
+
+  let _resolve
+  let _reject
+  const promise = new Promise((resolve, reject) => { _resolve = resolve; _reject = reject })
+
+  fastify.register(
+    async function (instance) {
+      instance.get('/ws', { websocket: true }, function (conn) {
+        conn.once('data', () => {
+          _reject('wrong-route')
+        })
+      })
+
+      instance.get('/ws-2', { websocket: true }, function (conn) {
+        conn.once('data', chunk => {
+          _resolve(chunk.toString())
+        })
+      })
+    })
+
+  await fastify.ready()
+  const ws = await fastify.injectWS('/ws-2')
+  ws.send(message)
+  t.same(await promise, message)
+})

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -115,3 +115,20 @@ test('use the upgrade context to upgrade if there is some hook', async (t) => {
   t.same(await promise, message)
   ws.terminate()
 })
+
+test('rejects if the websocket is not upgraded', async (t) => {
+  const fastify = buildFastify(t)
+
+  fastify.register(
+    async function (instance) {
+      instance.addHook('preValidation', async (request, reply) => {
+        return reply.code(401).send()
+      })
+
+      instance.get('/', { websocket: true }, function (conn) {
+      })
+    })
+
+  await fastify.ready()
+  t.rejects(fastify.injectWS('/'), 'Websocket injection failed')
+})

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -130,5 +130,5 @@ test('rejects if the websocket is not upgraded', async (t) => {
     })
 
   await fastify.ready()
-  t.rejects(fastify.injectWS('/'), 'Websocket injection failed')
+  t.rejects(fastify.injectWS('/'), 'Unexpected server response: 401')
 })

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -31,6 +31,7 @@ test('routes correctly the message', async (t) => {
   const ws = await fastify.injectWS('/ws')
   ws.send(message)
   t.same(await promise, message)
+  ws.terminate()
 })
 
 test('redirect on / if no path specified', async (t) => {
@@ -53,6 +54,7 @@ test('redirect on / if no path specified', async (t) => {
   const ws = await fastify.injectWS()
   ws.send(message)
   t.same(await promise, message)
+  ws.terminate()
 })
 
 test('routes correctly the message between two routes', async (t) => {
@@ -82,4 +84,5 @@ test('routes correctly the message between two routes', async (t) => {
   const ws = await fastify.injectWS('/ws-2')
   ws.send(message)
   t.same(await promise, message)
+  ws.terminate()
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,6 @@ declare module 'fastify' {
     ((path?: string, upgradeContext?: Partial<RawRequest>) => Promise<WebSocket>)
 
   interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
-    get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider>,
     websocketServer: WebSocket.Server,
     injectWS: InjectWSFn<RawRequest>
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,10 +27,13 @@ declare module 'fastify' {
     websocket?: boolean;
   }
 
+  type InjectWSFn<RawRequest> =
+    ((path?: string, upgradeContext?: Partial<RawRequest>) => Promise<WebSocket>)
+
   interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
     get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider>,
     websocketServer: WebSocket.Server,
-    injectWS: (path?: string) => Promise<WebSocket>
+    injectWS: InjectWSFn<RawRequest>
   }
 
   interface FastifyRequest {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,6 +30,7 @@ declare module 'fastify' {
   interface FastifyInstance<RawServer, RawRequest, RawReply, Logger, TypeProvider> {
     get: RouteShorthandMethod<RawServer, RawRequest, RawReply, TypeProvider>,
     websocketServer: WebSocket.Server,
+    injectWS: (path?: string) => Promise<WebSocket>
   }
 
   interface FastifyRequest {
@@ -66,7 +67,6 @@ type FastifyWebsocket = FastifyPluginCallback<fastifyWebsocket.WebsocketPluginOp
 declare namespace fastifyWebsocket {
 
   interface WebSocketServerOptions extends Omit<WebSocket.ServerOptions, "path"> { }
-  
   export type WebsocketHandler<
     RawServer extends RawServerBase = RawServerDefault,
     RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
@@ -80,18 +80,15 @@ declare namespace fastifyWebsocket {
     connection: SocketStream,
     request: FastifyRequest<RequestGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>
   ) => void | Promise<any>;
-  
   export interface SocketStream extends Duplex {
     socket: WebSocket;
   }
-  
   export interface WebsocketPluginOptions {
     errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply) => void;
     options?: WebSocketServerOptions;
     connectionOptions?: DuplexOptions;
     preClose?: preCloseHookHandler | preCloseAsyncHookHandler;
   }
-
   export interface RouteOptions<
     RawServer extends RawServerBase = RawServerDefault,
     RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,12 +1,11 @@
 import fastifyWebsocket, { WebsocketHandler, SocketStream, fastifyWebsocket as namedFastifyWebsocket, default as defaultFastifyWebsocket } from '..';
 import type { IncomingMessage } from "http";
-import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface, FastifyBaseLogger, RawServerDefault, FastifySchema, RawRequestDefaultExpression, RawServerBase, ContextConfigDefault, RawReplyDefaultExpression } from 'fastify';
-import { expectAssignable, expectError, expectType } from 'tsd';
+import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface, FastifyBaseLogger, RawServerDefault, FastifySchema, RawRequestDefaultExpression } from 'fastify';
+import { expectType } from 'tsd';
 import { Server } from 'ws';
 import { RouteGenericInterface } from 'fastify/types/route';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
-import { Static, Type } from '@sinclair/typebox'
-import { ResolveFastifyRequestType } from 'fastify/types/type-provider';
+import { Type } from '@sinclair/typebox'
 
 const app: FastifyInstance = fastify();
 app.register(fastifyWebsocket);
@@ -22,20 +21,16 @@ app.register(fastifyWebsocket, {
   }
 });
 app.register(fastifyWebsocket, { options: { perMessageDeflate: true } });
-app.register(fastifyWebsocket, { preClose: function syncPreclose() { } });
-app.register(fastifyWebsocket, { preClose: async function asyncPreclose() { } });
+app.register(fastifyWebsocket, { preClose: function syncPreclose() {} });
+app.register(fastifyWebsocket, { preClose: async function asyncPreclose(){} });
 
-app.injectWS()
-app.injectWS('/test')
-app.injectWS('/test', { headers: { 'test': 'test' } })
-expectError(app.injectWS({ headers: { 'test': "test" } }))
-
-app.get('/websockets-via-inferrence', { websocket: true }, async function(connection, request) {
+app.get('/websockets-via-inferrence', { websocket: true }, async function (connection, request) {
   expectType<FastifyInstance>(this);
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
   expectType<FastifyRequest<RequestGenericInterface>>(request)
   expectType<boolean>(request.ws);
+  expectType<FastifyBaseLogger>(request.log);
 });
 
 const handler: WebsocketHandler = async (connection, request) => {
@@ -94,7 +89,7 @@ app.get<{ Params: { foo: string }, Body: { bar: string }, Querystring: { search:
   expectType<{ foo: string }>(request.params);
   expectType<{ bar: string }>(request.body);
   expectType<{ search: string }>(request.query);
-  expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
+  expectType< IncomingMessage['headers'] & { auth: string }>(request.headers);
 });
 
 
@@ -105,7 +100,7 @@ app.route<{ Params: { foo: string }, Body: { bar: string }, Querystring: { searc
     expectType<{ foo: string }>(request.params);
     expectType<{ bar: string }>(request.body);
     expectType<{ search: string }>(request.query);
-    expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
+    expectType<IncomingMessage['headers'] & {  auth: string }>(request.headers);
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
@@ -131,12 +126,6 @@ const schema = {
     auth: Type.String()
   })
 };
-type SchemaType = {
-  params: Static<typeof schema.params>;
-  querystring: Static<typeof schema.querystring>;
-  body: Static<typeof schema.body>;
-  headers: Static<typeof schema.headers>;
-};
 
 const server = app.withTypeProvider<TypeBoxTypeProvider>();
 
@@ -159,40 +148,9 @@ server.route({
   },
 });
 
-// server.get('/websockets-type-inference',
-//   {
-//     websocket: true,
-//     schema
-//   },
-//   async function (connection, request) {
-//     expectType<FastifyInstance>(this);
-//     expectType<SocketStream>(connection);
-//     expectType<Server>(app.websocketServer);
-//     expectType<FastifyRequest<RequestGenericInterface, RawServerDefault, IncomingMessage, SchemaType, TypeBoxTypeProvider, unknown, FastifyBaseLogger>>(request);
-//     expectType<boolean>(request.ws);
-//     expectType<{ foo: string }>(request.params);
-//     expectType<{ bar: string }>(request.body);
-//     expectType<{ search: string }>(request.query);
-//     expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
-//   });
-
-// server.get('/not-websockets-type-inference',
-//   {
-//     websocket: false,
-//     schema
-//   },
-//   async (request, reply) => {
-//     expectType<FastifyRequest<RouteGenericInterface, RawServerDefault, IncomingMessage, SchemaType, TypeBoxTypeProvider, unknown, FastifyBaseLogger, ResolveFastifyRequestType<TypeBoxTypeProvider, FastifySchema, RouteGenericInterface>>>(request);
-//     expectType<FastifyReply<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RouteGenericInterface, ContextConfigDefault, SchemaType, TypeBoxTypeProvider>>(reply);
-//     expectType<{ foo: string }>(request.params);
-//     expectType<{ bar: string }>(request.body);
-//     expectType<{ search: string }>(request.query);
-//     expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
-//   });
-
 server.get('/websockets-no-type-inference',
   { websocket: true },
-  async function(connection, request) {
+  async function (connection, request) {
     expectType<FastifyInstance>(this);
     expectType<SocketStream>(connection);
     expectType<Server>(app.websocketServer);
@@ -204,6 +162,6 @@ server.get('/websockets-no-type-inference',
     expectType<IncomingMessage['headers']>(request.headers);
   });
 
-expectType<typeof fastifyWebsocket>(namedFastifyWebsocket);
-expectType<typeof fastifyWebsocket>(defaultFastifyWebsocket);
-
+  expectType<typeof fastifyWebsocket>(namedFastifyWebsocket);
+  expectType<typeof fastifyWebsocket>(defaultFastifyWebsocket);
+  

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import fastifyWebsocket, { WebsocketHandler, SocketStream, fastifyWebsocket as namedFastifyWebsocket, default as defaultFastifyWebsocket } from '..';
 import type { IncomingMessage } from "http";
 import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface, FastifyBaseLogger, RawServerDefault, FastifySchema, RawRequestDefaultExpression, RawServerBase, ContextConfigDefault, RawReplyDefaultExpression } from 'fastify';
-import { expectAssignable, expectType } from 'tsd';
+import { expectAssignable, expectError, expectType } from 'tsd';
 import { Server } from 'ws';
 import { RouteGenericInterface } from 'fastify/types/route';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
@@ -22,10 +22,15 @@ app.register(fastifyWebsocket, {
   }
 });
 app.register(fastifyWebsocket, { options: { perMessageDeflate: true } });
-app.register(fastifyWebsocket, { preClose: function syncPreclose() {} });
-app.register(fastifyWebsocket, { preClose: async function asyncPreclose(){} });
+app.register(fastifyWebsocket, { preClose: function syncPreclose() { } });
+app.register(fastifyWebsocket, { preClose: async function asyncPreclose() { } });
 
-app.get('/websockets-via-inferrence', { websocket: true }, async function (connection, request) {
+app.injectWS()
+app.injectWS('/test')
+app.injectWS('/test', { headers: { 'test': 'test' } })
+expectError(app.injectWS({ headers: { 'test': "test" } }))
+
+app.get('/websockets-via-inferrence', { websocket: true }, async function(connection, request) {
   expectType<FastifyInstance>(this);
   expectType<SocketStream>(connection);
   expectType<Server>(app.websocketServer);
@@ -89,7 +94,7 @@ app.get<{ Params: { foo: string }, Body: { bar: string }, Querystring: { search:
   expectType<{ foo: string }>(request.params);
   expectType<{ bar: string }>(request.body);
   expectType<{ search: string }>(request.query);
-  expectType< IncomingMessage['headers'] & { auth: string }>(request.headers);
+  expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
 });
 
 
@@ -100,7 +105,7 @@ app.route<{ Params: { foo: string }, Body: { bar: string }, Querystring: { searc
     expectType<{ foo: string }>(request.params);
     expectType<{ bar: string }>(request.body);
     expectType<{ search: string }>(request.query);
-    expectType<IncomingMessage['headers'] & {  auth: string }>(request.headers);
+    expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
   },
   wsHandler: (connection, request) => {
     expectType<SocketStream>(connection);
@@ -187,7 +192,7 @@ server.route({
 
 server.get('/websockets-no-type-inference',
   { websocket: true },
-  async function (connection, request) {
+  async function(connection, request) {
     expectType<FastifyInstance>(this);
     expectType<SocketStream>(connection);
     expectType<Server>(app.websocketServer);
@@ -199,6 +204,6 @@ server.get('/websockets-no-type-inference',
     expectType<IncomingMessage['headers']>(request.headers);
   });
 
-  expectType<typeof fastifyWebsocket>(namedFastifyWebsocket);
-  expectType<typeof fastifyWebsocket>(defaultFastifyWebsocket);
-  
+expectType<typeof fastifyWebsocket>(namedFastifyWebsocket);
+expectType<typeof fastifyWebsocket>(defaultFastifyWebsocket);
+


### PR DESCRIPTION
Now is possible to invoke an websocket handler without listening.

closes #35 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
