### PR TITLE
fix: provide websocket instead of stream to avoid potential backpressure issues (#289)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,32 @@ It allows to test easily a websocket endpoint.
 
 The signature of injectWS is the following: `([path], [upgradeContext])`.
 
+
+### Creating a stream from the WebSocket
+
+```js
+const Fastify = require('fastify')
+const FastifyWebSocket = require('@fastify/websocket')
+const ws = require('ws')
+
+const fastify = Fastify()
+await fastify.register(websocket)
+
+fastify.get('/', { websocket: true }, (socket, req) => {
+  const stream = ws.createWebSocketStream(socket, { /* options */ })
+  stream.setEncoding('utf8')
+  stream.write('hello client')
+  
+  stream.on('data', function (data) {
+    // Make sure to set up a data handler or read all the incoming
+    // data in another way, otherwise stream backpressure will cause
+    // the underlying WebSocket object to get paused.
+  })
+})
+
+await fastify.listen({ port: 3000 })
+```
+
 #### App.js
 
 ```js

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const http = require('node:http')
-const util = require('node:util')
 const split = require('split2')
 const test = require('tap').test
 const Fastify = require('fastify')
@@ -22,29 +21,27 @@ test('Should expose a websocket', async (t) => {
 
   await fastify.register(fastifyWebsocket)
 
-  fastify.get('/', { websocket: true }, (connection) => {
-    connection.setEncoding('utf8')
-    t.teardown(() => connection.destroy())
+  fastify.get('/', { websocket: true }, (socket) => {
+    t.teardown(() => socket.close())
 
-    connection.once('data', (chunk) => {
-      t.equal(chunk, 'hello server')
-      connection.write('hello client')
-      connection.end()
+    socket.once('message', (chunk) => {
+      t.equal(chunk.toString(), 'hello server')
+      socket.send('hello client')
     })
   })
 
   await fastify.listen({ port: 0 })
 
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  t.teardown(() => ws.close())
 
-  client.setEncoding('utf8')
-  client.write('hello server')
+  const chunkPromise = once(ws, 'message')
+  await once(ws, 'open')
+  ws.send('hello server')
 
-  const [chunk] = await once(client, 'data')
-  t.equal(chunk, 'hello client')
-  client.end()
+  const [chunk] = await chunkPromise
+  t.equal(chunk.toString(), 'hello client')
+  ws.close()
 })
 
 test('Should fail if custom errorHandler is not a function', async (t) => {
@@ -59,8 +56,8 @@ test('Should fail if custom errorHandler is not a function', async (t) => {
     t.equal(err.message, 'invalid errorHandler function')
   }
 
-  fastify.get('/', { websocket: true }, (connection) => {
-    t.teardown(() => connection.destroy())
+  fastify.get('/', { websocket: true }, (socket) => {
+    t.teardown(() => socket.close())
   })
 
   try {
@@ -88,17 +85,17 @@ test('Should run custom errorHandler on wildcard route handler error', async (t)
     }
   })
 
-  fastify.get('/*', { websocket: true }, (conn) => {
-    conn.pipe(conn)
-    t.teardown(() => conn.destroy())
+  fastify.get('/*', { websocket: true }, (socket) => {
+    socket.on('message', (data) => socket.send(data))
+    t.teardown(() => socket.close())
     return Promise.reject(new Error('Fail'))
   })
 
   await fastify.listen({ port: 0 })
 
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  t.teardown(() => ws.close())
+
   await p
 })
 
@@ -120,16 +117,15 @@ test('Should run custom errorHandler on error inside websocket handler', async (
 
   await fastify.register(fastifyWebsocket, options)
 
-  fastify.get('/', { websocket: true }, function wsHandler (conn) {
-    conn.pipe(conn)
-    t.teardown(() => conn.destroy())
+  fastify.get('/', { websocket: true }, function wsHandler (socket) {
+    socket.on('message', (data) => socket.send(data))
+    t.teardown(() => socket.close())
     throw new Error('Fail')
   })
 
   await fastify.listen({ port: 0 })
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  t.teardown(() => ws.close())
 
   await p
 })
@@ -152,20 +148,20 @@ test('Should run custom errorHandler on error inside async websocket handler', a
 
   await fastify.register(fastifyWebsocket, options)
 
-  fastify.get('/', { websocket: true }, async function wsHandler (conn) {
-    conn.pipe(conn)
-    t.teardown(() => conn.destroy())
+  fastify.get('/', { websocket: true }, async function wsHandler (socket) {
+    socket.on('message', (data) => socket.send(data))
+    t.teardown(() => socket.close())
     throw new Error('Fail')
   })
 
   await fastify.listen({ port: 0 })
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  t.teardown(() => ws.close())
+
   await p
 })
 
-test('Should be able to pass custom options to websocket-stream', async (t) => {
+test('Should be able to pass custom options to ws', async (t) => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -181,27 +177,27 @@ test('Should be able to pass custom options to websocket-stream', async (t) => {
 
   await fastify.register(fastifyWebsocket, { options })
 
-  fastify.get('/*', { websocket: true }, (connection) => {
-    connection.pipe(connection)
-    t.teardown(() => connection.destroy())
+  fastify.get('/*', { websocket: true }, (socket) => {
+    socket.on('message', (data) => socket.send(data))
+    t.teardown(() => socket.close())
   })
 
   await fastify.listen({ port: 0 })
 
   const clientOptions = { headers: { 'x-custom-header': 'fastify is awesome !' } }
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port, clientOptions)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  const chunkPromise = once(ws, 'message')
+  await once(ws, 'open')
+  t.teardown(() => ws.close())
 
-  client.setEncoding('utf8')
-  client.write('hello')
+  ws.send('hello')
 
-  const [chunk] = await once(client, 'data')
-  t.equal(chunk, 'hello')
-  client.end()
+  const [chunk] = await chunkPromise
+  t.equal(chunk.toString(), 'hello')
+  ws.close()
 })
 
-test('Should warn if path option is provided to websocket-stream', async (t) => {
+test('Should warn if path option is provided to ws', async (t) => {
   t.plan(3)
   const logStream = split(JSON.parse)
   const fastify = Fastify({
@@ -221,27 +217,27 @@ test('Should warn if path option is provided to websocket-stream', async (t) => 
   const options = { path: '/' }
   await fastify.register(fastifyWebsocket, { options })
 
-  fastify.get('/*', { websocket: true }, (connection) => {
-    connection.pipe(connection)
-    t.teardown(() => connection.destroy())
+  fastify.get('/*', { websocket: true }, (socket) => {
+    socket.on('message', (data) => socket.send(data))
+    t.teardown(() => socket.close())
   })
 
   await fastify.listen({ port: 0 })
 
   const clientOptions = { headers: { 'x-custom-header': 'fastify is awesome !' } }
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port, clientOptions)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  const chunkPromise = once(ws, 'message')
+  await once(ws, 'open')
+  t.teardown(() => ws.close())
 
-  client.setEncoding('utf8')
-  client.write('hello')
+  ws.send('hello')
 
-  const [chunk] = await once(client, 'data')
-  t.equal(chunk, 'hello')
-  client.end()
+  const [chunk] = await chunkPromise
+  t.equal(chunk.toString(), 'hello')
+  ws.close()
 })
 
-test('Should be able to pass a custom server option to websocket-stream', async (t) => {
+test('Should be able to pass a custom server option to ws', async (t) => {
   // We create an external server
   const externalServerPort = 3000
   const externalServer = http
@@ -263,26 +259,26 @@ test('Should be able to pass a custom server option to websocket-stream', async 
 
   await fastify.register(fastifyWebsocket, { options })
 
-  fastify.get('/', { websocket: true }, (connection) => {
-    connection.pipe(connection)
-    t.teardown(() => connection.destroy())
+  fastify.get('/', { websocket: true }, (socket) => {
+    socket.on('message', (data) => socket.send(data))
+    t.teardown(() => socket.close())
   })
 
   await fastify.ready()
 
   const ws = new WebSocket('ws://localhost:' + externalServerPort)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  const chunkPromise = once(ws, 'message')
+  await once(ws, 'open')
+  t.teardown(() => ws.close())
 
-  client.setEncoding('utf8')
-  client.write('hello')
+  ws.send('hello')
 
-  const [chunk] = await once(client, 'data')
-  t.equal(chunk, 'hello')
-  client.end()
+  const [chunk] = await chunkPromise
+  t.equal(chunk.toString(), 'hello')
+  ws.close()
 })
 
-test('Should be able to pass clientTracking option in false to websocket-stream', (t) => {
+test('Should be able to pass clientTracking option in false to ws', (t) => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -293,8 +289,8 @@ test('Should be able to pass clientTracking option in false to websocket-stream'
 
   fastify.register(fastifyWebsocket, { options })
 
-  fastify.get('/*', { websocket: true }, (connection) => {
-    connection.destroy()
+  fastify.get('/*', { websocket: true }, (socket) => {
+    socket.close()
   })
 
   fastify.listen({ port: 0 }, (err) => {
@@ -304,46 +300,6 @@ test('Should be able to pass clientTracking option in false to websocket-stream'
       t.error(err)
     })
   })
-})
-
-test('Should be able to pass custom connectionOptions to createWebSocketStream', async (t) => {
-  t.plan(2)
-
-  const fastify = Fastify()
-  t.teardown(() => fastify.close())
-
-  const connectionOptions = {
-    readableObjectMode: true
-  }
-
-  await fastify.register(fastifyWebsocket, { connectionOptions })
-
-  let _resolve
-  const p = new Promise((resolve) => {
-    _resolve = resolve
-  })
-
-  fastify.get('/', { websocket: true }, (connection) => {
-    t.equal(connection.readableObjectMode, true)
-    connection.socket.binaryType = 'arraybuffer'
-
-    connection.once('data', (chunk) => {
-      const message = new util.TextDecoder().decode(chunk)
-      t.equal(message, 'Hello')
-      _resolve()
-    })
-    t.teardown(() => connection.destroy())
-  })
-
-  await fastify.listen({ port: 0 })
-
-  const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
-
-  client.setEncoding('utf8')
-  client.write('Hello')
-  await p
 })
 
 test('Should be able to pass preClose option to override default', async (t) => {
@@ -362,29 +318,27 @@ test('Should be able to pass preClose option to override default', async (t) => 
 
   await fastify.register(fastifyWebsocket, { preClose })
 
-  fastify.get('/', { websocket: true }, (connection) => {
-    connection.setEncoding('utf8')
-    t.teardown(() => connection.destroy())
+  fastify.get('/', { websocket: true }, (socket) => {
+    t.teardown(() => socket.close())
 
-    connection.once('data', (chunk) => {
-      t.equal(chunk, 'hello server')
-      connection.write('hello client')
-      connection.end()
+    socket.once('message', (chunk) => {
+      t.equal(chunk.toString(), 'hello server')
+      socket.send('hello client')
     })
   })
 
   await fastify.listen({ port: 0 })
 
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
-  t.teardown(() => client.destroy())
+  t.teardown(() => ws.close())
 
-  client.setEncoding('utf8')
-  client.write('hello server')
+  const chunkPromise = once(ws, 'message')
+  await once(ws, 'open')
+  ws.send('hello server')
 
-  const [chunk] = await once(client, 'data')
-  t.equal(chunk, 'hello client')
-  client.end()
+  const [chunk] = await chunkPromise
+  t.equal(chunk.toString(), 'hello client')
+  ws.close()
 
   await fastify.close()
 })
@@ -403,8 +357,8 @@ test('Should fail if custom preClose is not a function', async (t) => {
     t.equal(err.message, 'invalid preClose function')
   }
 
-  fastify.get('/', { websocket: true }, (connection) => {
-    t.teardown(() => connection.destroy())
+  fastify.get('/', { websocket: true }, (socket) => {
+    t.teardown(() => socket.close())
   })
 
   try {
@@ -422,30 +376,27 @@ test('Should gracefully close with a connected client', async (t) => {
   await fastify.register(fastifyWebsocket)
   let serverConnEnded
 
-  fastify.get('/', { websocket: true }, (connection) => {
-    connection.setEncoding('utf8')
-    connection.write('hello client')
+  fastify.get('/', { websocket: true }, (socket) => {
+    socket.send('hello client')
 
-    connection.once('data', (chunk) => {
-      t.equal(chunk, 'hello server')
+    socket.once('message', (chunk) => {
+      t.equal(chunk.toString(), 'hello server')
     })
 
-    serverConnEnded = once(connection, 'end')
+    serverConnEnded = once(socket, 'close')
     // this connection stays alive untile we close the server
   })
 
   await fastify.listen({ port: 0 })
 
   const ws = new WebSocket('ws://localhost:' + fastify.server.address().port)
-  const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8' })
+  const chunkPromise = once(ws, 'message')
+  await once(ws, 'open')
+  ws.send('hello server')
 
-  client.setEncoding('utf8')
-  client.write('hello server')
-
-  const ended = once(client, 'end')
-
-  const [chunk] = await once(client, 'data')
-  t.equal(chunk, 'hello client')
+  const ended = once(ws, 'close')
+  const [chunk] = await chunkPromise
+  t.equal(chunk.toString(), 'hello client')
   await fastify.close()
   await ended
   await serverConnEnded
@@ -469,9 +420,9 @@ test('Should gracefully close when clients attempt to connect after calling clos
 
   await fastify.register(fastifyWebsocket)
 
-  fastify.get('/', { websocket: true }, (connection) => {
+  fastify.get('/', { websocket: true }, (socket) => {
     t.pass('received client connection')
-    connection.destroy()
+    socket.close()
     // this connection stays alive until we close the server
   })
 
@@ -505,7 +456,7 @@ test('Should keep accepting connection', { skip: !timersPromises }, async t => {
 
   await fastify.register(fastifyWebsocket)
 
-  fastify.get('/', { websocket: true }, ({ socket }) => {
+  fastify.get('/', { websocket: true }, (socket) => {
     socket.on('message', () => {
       unhandled--
     })
@@ -561,7 +512,7 @@ test('Should keep processing message when many medium sized messages are sent', 
 
   await fastify.register(fastifyWebsocket)
 
-  fastify.get('/', { websocket: true }, ({ socket }) => {
+  fastify.get('/', { websocket: true }, (socket) => {
     socket.on('message', () => {
       socket.send('handled')
     })
@@ -631,7 +582,7 @@ test('Should Handle WebSocket errors to avoid Node.js crashes', async t => {
   const fastify = Fastify()
   await fastify.register(fastifyWebsocket)
 
-  fastify.get('/', { websocket: true }, ({ socket }) => {
+  fastify.get('/', { websocket: true }, (socket) => {
     socket.on('error', err => {
       t.equal(err.code, 'WS_ERR_UNEXPECTED_RSV_2_3')
     })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -22,7 +22,7 @@ test('Should expose a websocket', async (t) => {
   await fastify.register(fastifyWebsocket)
 
   fastify.get('/', { websocket: true }, (socket) => {
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
 
     socket.once('message', (chunk) => {
       t.equal(chunk.toString(), 'hello server')
@@ -57,7 +57,7 @@ test('Should fail if custom errorHandler is not a function', async (t) => {
   }
 
   fastify.get('/', { websocket: true }, (socket) => {
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
   })
 
   try {
@@ -87,7 +87,7 @@ test('Should run custom errorHandler on wildcard route handler error', async (t)
 
   fastify.get('/*', { websocket: true }, (socket) => {
     socket.on('message', (data) => socket.send(data))
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
     return Promise.reject(new Error('Fail'))
   })
 
@@ -119,7 +119,7 @@ test('Should run custom errorHandler on error inside websocket handler', async (
 
   fastify.get('/', { websocket: true }, function wsHandler (socket) {
     socket.on('message', (data) => socket.send(data))
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
     throw new Error('Fail')
   })
 
@@ -150,7 +150,7 @@ test('Should run custom errorHandler on error inside async websocket handler', a
 
   fastify.get('/', { websocket: true }, async function wsHandler (socket) {
     socket.on('message', (data) => socket.send(data))
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
     throw new Error('Fail')
   })
 
@@ -179,7 +179,7 @@ test('Should be able to pass custom options to ws', async (t) => {
 
   fastify.get('/*', { websocket: true }, (socket) => {
     socket.on('message', (data) => socket.send(data))
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
   })
 
   await fastify.listen({ port: 0 })
@@ -219,7 +219,7 @@ test('Should warn if path option is provided to ws', async (t) => {
 
   fastify.get('/*', { websocket: true }, (socket) => {
     socket.on('message', (data) => socket.send(data))
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
   })
 
   await fastify.listen({ port: 0 })
@@ -261,7 +261,7 @@ test('Should be able to pass a custom server option to ws', async (t) => {
 
   fastify.get('/', { websocket: true }, (socket) => {
     socket.on('message', (data) => socket.send(data))
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
   })
 
   await fastify.ready()
@@ -319,7 +319,7 @@ test('Should be able to pass preClose option to override default', async (t) => 
   await fastify.register(fastifyWebsocket, { preClose })
 
   fastify.get('/', { websocket: true }, (socket) => {
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
 
     socket.once('message', (chunk) => {
       t.equal(chunk.toString(), 'hello server')
@@ -358,7 +358,7 @@ test('Should fail if custom preClose is not a function', async (t) => {
   }
 
   fastify.get('/', { websocket: true }, (socket) => {
-    t.teardown(() => socket.close())
+    t.teardown(() => socket.terminate())
   })
 
   try {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -23,7 +23,7 @@ test('Should run onRequest, preValidation, preHandler hooks', t => {
 
     fastify.get('/echo', { websocket: true }, (socket, request) => {
       socket.send('hello client')
-      t.teardown(() => socket.close())
+      t.teardown(() => socket.terminate())
 
       socket.once('message', (chunk) => {
         t.equal(chunk.toString(), 'hello server')
@@ -61,7 +61,7 @@ test('Should not run onTimeout hook', t => {
     fastify.get('/echo', { websocket: true }, (socket, request) => {
       socket.send('hello client')
       request.raw.setTimeout(50)
-      t.teardown(() => socket.close())
+      t.teardown(() => socket.terminate())
     })
   })
 
@@ -204,7 +204,7 @@ test('Should not run onError hook if reply was already hijacked (error thrown in
     fastify.addHook('onError', async (request, reply) => t.fail('called', 'onError'))
 
     fastify.get('/echo', { websocket: true }, async (socket, request) => {
-      t.teardown(() => socket.close())
+      t.teardown(() => socket.terminate())
       throw new Error('Fail')
     })
   })
@@ -232,7 +232,7 @@ test('Should not run preSerialization/onSend hooks', t => {
 
     fastify.get('/echo', { websocket: true }, async (socket, request) => {
       socket.send('hello client')
-      t.teardown(() => socket.close())
+      t.teardown(() => socket.terminate())
     })
   })
 
@@ -296,7 +296,7 @@ test('Should run async hooks and still deliver quickly sent messages', (t) => {
 
     fastify.get('/echo', { websocket: true }, (socket, request) => {
       socket.send('hello client')
-      t.teardown(() => socket.close())
+      t.teardown(() => socket.terminate())
 
       socket.on('message', (message) => {
         t.equal(message.toString('utf-8'), 'hello server')

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -355,7 +355,7 @@ test('Should not hijack reply for an normal request to a websocket route that is
 })
 
 test('Should not hijack reply for an WS request to a WS route that gets sent a normal HTTP response in a hook', t => {
-  t.plan(5)
+  t.plan(2)
   const stream = split(JSON.parse)
   const fastify = Fastify({ logger: { stream } })
 
@@ -370,7 +370,9 @@ test('Should not hijack reply for an WS request to a WS route that gets sent a n
   })
 
   stream.on('data', (chunk) => {
-    t.ok(chunk.level < 50)
+    if (chunk.level >= 50) {
+      t.fail()
+    }
   })
 
   fastify.listen({ port: 0 }, err => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -21,14 +21,12 @@ test('Should run onRequest, preValidation, preHandler hooks', t => {
     fastify.addHook('preValidation', async (request, reply) => t.ok('called', 'preValidation'))
     fastify.addHook('preHandler', async (request, reply) => t.ok('called', 'preHandler'))
 
-    fastify.get('/echo', { websocket: true }, (conn, request) => {
-      conn.setEncoding('utf8')
-      conn.write('hello client')
-      t.teardown(conn.destroy.bind(conn))
+    fastify.get('/echo', { websocket: true }, (socket, request) => {
+      socket.send('hello client')
+      t.teardown(() => socket.close())
 
-      conn.once('data', chunk => {
-        t.equal(chunk, 'hello server')
-        conn.end()
+      socket.once('message', (chunk) => {
+        t.equal(chunk.toString(), 'hello server')
       })
     })
   })
@@ -60,11 +58,10 @@ test('Should not run onTimeout hook', t => {
   fastify.register(async function () {
     fastify.addHook('onTimeout', async (request, reply) => t.fail('called', 'onTimeout'))
 
-    fastify.get('/echo', { websocket: true }, (conn, request) => {
-      conn.setEncoding('utf8')
-      conn.write('hello client')
+    fastify.get('/echo', { websocket: true }, (socket, request) => {
+      socket.send('hello client')
       request.raw.setTimeout(50)
-      t.teardown(conn.destroy.bind(conn))
+      t.teardown(() => socket.close())
     })
   })
 
@@ -206,8 +203,8 @@ test('Should not run onError hook if reply was already hijacked (error thrown in
   fastify.register(async function (fastify) {
     fastify.addHook('onError', async (request, reply) => t.fail('called', 'onError'))
 
-    fastify.get('/echo', { websocket: true }, async (conn, request) => {
-      t.teardown(conn.destroy.bind(conn))
+    fastify.get('/echo', { websocket: true }, async (socket, request) => {
+      t.teardown(() => socket.close())
       throw new Error('Fail')
     })
   })
@@ -233,11 +230,9 @@ test('Should not run preSerialization/onSend hooks', t => {
     fastify.addHook('onSend', async (request, reply) => t.fail('called', 'onSend'))
     fastify.addHook('preSerialization', async (request, reply) => t.fail('called', 'preSerialization'))
 
-    fastify.get('/echo', { websocket: true }, async (conn, request) => {
-      conn.setEncoding('utf8')
-      conn.write('hello client')
-      t.teardown(conn.destroy.bind(conn))
-      conn.end()
+    fastify.get('/echo', { websocket: true }, async (socket, request) => {
+      socket.send('hello client')
+      t.teardown(() => socket.close())
     })
   })
 
@@ -299,14 +294,12 @@ test('Should run async hooks and still deliver quickly sent messages', (t) => {
       async () => await new Promise((resolve) => setTimeout(resolve, 25))
     )
 
-    fastify.get('/echo', { websocket: true }, (conn, request) => {
-      conn.setEncoding('utf8')
-      conn.write('hello client')
-      t.teardown(conn.destroy.bind(conn))
+    fastify.get('/echo', { websocket: true }, (socket, request) => {
+      socket.send('hello client')
+      t.teardown(() => socket.close())
 
-      conn.socket.on('message', (message) => {
+      socket.on('message', (message) => {
         t.equal(message.toString('utf-8'), 'hello server')
-        conn.end()
       })
     })
   })
@@ -362,7 +355,7 @@ test('Should not hijack reply for an normal request to a websocket route that is
 })
 
 test('Should not hijack reply for an WS request to a WS route that gets sent a normal HTTP response in a hook', t => {
-  t.plan(6)
+  t.plan(5)
   const stream = split(JSON.parse)
   const fastify = Fastify({ logger: { stream } })
 

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -20,8 +20,8 @@ test('routes correctly the message', async (t) => {
 
   fastify.register(
     async function (instance) {
-      instance.get('/ws', { websocket: true }, function (conn) {
-        conn.once('data', chunk => {
+      instance.get('/ws', { websocket: true }, function (socket) {
+        socket.once('message', chunk => {
           _resolve(chunk.toString())
         })
       })
@@ -43,8 +43,8 @@ test('redirect on / if no path specified', async (t) => {
 
   fastify.register(
     async function (instance) {
-      instance.get('/', { websocket: true }, function (conn) {
-        conn.once('data', chunk => {
+      instance.get('/', { websocket: true }, function (socket) {
+        socket.once('message', chunk => {
           _resolve(chunk.toString())
         })
       })
@@ -67,14 +67,14 @@ test('routes correctly the message between two routes', async (t) => {
 
   fastify.register(
     async function (instance) {
-      instance.get('/ws', { websocket: true }, function (conn) {
-        conn.once('data', () => {
+      instance.get('/ws', { websocket: true }, function (socket) {
+        socket.once('message', chunk => {
           _reject('wrong-route')
         })
       })
 
-      instance.get('/ws-2', { websocket: true }, function (conn) {
-        conn.once('data', chunk => {
+      instance.get('/ws-2', { websocket: true }, function (socket) {
+        socket.once('message', chunk => {
           _resolve(chunk.toString())
         })
       })
@@ -102,8 +102,8 @@ test('use the upgrade context to upgrade if there is some hook', async (t) => {
         }
       })
 
-      instance.get('/', { websocket: true }, function (conn) {
-        conn.once('data', chunk => {
+      instance.get('/', { websocket: true }, function (socket) {
+        socket.once('message', chunk => {
           _resolve(chunk.toString())
         })
       })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,6 @@ import { IncomingMessage, ServerResponse, Server } from 'http';
 import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance, FastifySchema, FastifyTypeProvider, FastifyTypeProviderDefault, FastifyBaseLogger } from 'fastify';
 import * as fastify from 'fastify';
 import * as WebSocket from 'ws';
-import { Duplex, DuplexOptions } from 'stream';
 import { FastifyReply } from 'fastify/types/reply';
 import { preCloseHookHandler, preCloseAsyncHookHandler } from 'fastify/types/hooks';
 import { RouteGenericInterface } from 'fastify/types/route';
@@ -80,16 +79,12 @@ declare namespace fastifyWebsocket {
     Logger extends FastifyBaseLogger = FastifyBaseLogger
   > = (
     this: FastifyInstance<Server, IncomingMessage, ServerResponse>,
-    connection: SocketStream,
+    socket: WebSocket.WebSocket,
     request: FastifyRequest<RequestGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>
   ) => void | Promise<any>;
-  export interface SocketStream extends Duplex {
-    socket: WebSocket;
-  }
   export interface WebsocketPluginOptions {
-    errorHandler?: (this: FastifyInstance, error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply) => void;
+    errorHandler?: (this: FastifyInstance, error: Error, socket: WebSocket.WebSocket, request: FastifyRequest, reply: FastifyReply) => void;
     options?: WebSocketServerOptions;
-    connectionOptions?: DuplexOptions;
     preClose?: preCloseHookHandler | preCloseAsyncHookHandler;
   }
   export interface RouteOptions<

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,8 +1,8 @@
-import fastifyWebsocket, { WebsocketHandler, SocketStream, fastifyWebsocket as namedFastifyWebsocket, default as defaultFastifyWebsocket } from '..';
+import fastifyWebsocket, { WebsocketHandler, fastifyWebsocket as namedFastifyWebsocket, default as defaultFastifyWebsocket } from '..';
 import type { IncomingMessage } from "http";
 import fastify, { RouteOptions, FastifyRequest, FastifyInstance, FastifyReply, RequestGenericInterface, FastifyBaseLogger, RawServerDefault, FastifySchema, RawRequestDefaultExpression } from 'fastify';
 import { expectType } from 'tsd';
-import { Server } from 'ws';
+import { Server, WebSocket } from 'ws';
 import { RouteGenericInterface } from 'fastify/types/route';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox'
@@ -12,10 +12,10 @@ app.register(fastifyWebsocket);
 app.register(fastifyWebsocket, {});
 app.register(fastifyWebsocket, { options: { maxPayload: 123 } });
 app.register(fastifyWebsocket, {
-  errorHandler: function errorHandler(error: Error, connection: SocketStream, request: FastifyRequest, reply: FastifyReply): void {
+  errorHandler: function errorHandler(error: Error, socket: WebSocket, request: FastifyRequest, reply: FastifyReply): void {
     expectType<FastifyInstance>(this);
     expectType<Error>(error)
-    expectType<SocketStream>(connection)
+    expectType<WebSocket>(socket)
     expectType<FastifyRequest>(request)
     expectType<FastifyReply>(reply)
   }
@@ -24,17 +24,17 @@ app.register(fastifyWebsocket, { options: { perMessageDeflate: true } });
 app.register(fastifyWebsocket, { preClose: function syncPreclose() {} });
 app.register(fastifyWebsocket, { preClose: async function asyncPreclose(){} });
 
-app.get('/websockets-via-inferrence', { websocket: true }, async function (connection, request) {
+app.get('/websockets-via-inferrence', { websocket: true }, async function (socket, request) {
   expectType<FastifyInstance>(this);
-  expectType<SocketStream>(connection);
+  expectType<WebSocket>(socket);
   expectType<Server>(app.websocketServer);
   expectType<FastifyRequest<RequestGenericInterface>>(request)
   expectType<boolean>(request.ws);
   expectType<FastifyBaseLogger>(request.log);
 });
 
-const handler: WebsocketHandler = async (connection, request) => {
-  expectType<SocketStream>(connection);
+const handler: WebsocketHandler = async (socket, request) => {
+  expectType<WebSocket>(socket);
   expectType<Server>(app.websocketServer);
   expectType<FastifyRequest<RequestGenericInterface>>(request)
 }
@@ -60,8 +60,8 @@ app.route({
     expectType<FastifyReply>(reply);
     expectType<boolean>(request.ws);
   },
-  wsHandler: (connection, request) => {
-    expectType<SocketStream>(connection);
+  wsHandler: (socket, request) => {
+    expectType<WebSocket>(socket);
     expectType<FastifyRequest<RouteGenericInterface>>(request);
     expectType<boolean>(request.ws);
   },
@@ -74,8 +74,8 @@ const augmentedRouteOptions: RouteOptions = {
     expectType<FastifyRequest>(request);
     expectType<FastifyReply>(reply);
   },
-  wsHandler: (connection, request) => {
-    expectType<SocketStream>(connection);
+  wsHandler: (socket, request) => {
+    expectType<WebSocket>(socket);
     expectType<FastifyRequest<RouteGenericInterface>>(request)
   },
 };
@@ -84,8 +84,8 @@ app.route(augmentedRouteOptions);
 
 app.get<{ Params: { foo: string }, Body: { bar: string }, Querystring: { search: string }, Headers: { auth: string } }>('/shorthand-explicit-types', {
   websocket: true
-}, async (connection, request) => {
-  expectType<SocketStream>(connection);
+}, async (socket, request) => {
+  expectType<WebSocket>(socket);
   expectType<{ foo: string }>(request.params);
   expectType<{ bar: string }>(request.body);
   expectType<{ search: string }>(request.query);
@@ -102,8 +102,8 @@ app.route<{ Params: { foo: string }, Body: { bar: string }, Querystring: { searc
     expectType<{ search: string }>(request.query);
     expectType<IncomingMessage['headers'] & {  auth: string }>(request.headers);
   },
-  wsHandler: (connection, request) => {
-    expectType<SocketStream>(connection);
+  wsHandler: (socket, request) => {
+    expectType<WebSocket>(socket);
     expectType<{ foo: string }>(request.params);
     expectType<{ bar: string }>(request.body);
     expectType<{ search: string }>(request.query);
@@ -139,8 +139,8 @@ server.route({
     expectType<{ search: string }>(request.query);
     expectType<IncomingMessage['headers'] & { auth: string }>(request.headers);
   },
-  wsHandler: (connection, request) => {
-    expectType<SocketStream>(connection);
+  wsHandler: (socket, request) => {
+    expectType<WebSocket>(socket);
     expectType<{ foo: string }>(request.params);
     expectType<{ bar: string }>(request.body);
     expectType<{ search: string }>(request.query);
@@ -150,9 +150,9 @@ server.route({
 
 server.get('/websockets-no-type-inference',
   { websocket: true },
-  async function (connection, request) {
+  async function (socket, request) {
     expectType<FastifyInstance>(this);
-    expectType<SocketStream>(connection);
+    expectType<WebSocket>(socket);
     expectType<Server>(app.websocketServer);
     expectType<FastifyRequest<RequestGenericInterface, RawServerDefault, RawRequestDefaultExpression, FastifySchema, TypeBoxTypeProvider, unknown, FastifyBaseLogger>>(request);
     expectType<boolean>(request.ws);


### PR DESCRIPTION
Now `createWebSocketStream` is not called therefore there are no memory leaks/backpressure to worry about.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
