### PR TITLE
chore: correcting README example for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ const FastifyWebSocket = require('@fastify/websocket')
 const ws = require('ws')
 
 const fastify = Fastify()
-await fastify.register(websocket)
+await fastify.register(FastifyWebSocket)
 
 fastify.get('/', { websocket: true }, (socket, req) => {
   const stream = ws.createWebSocketStream(socket, { /* options */ })
@@ -332,6 +332,7 @@ test('connect to /', async (t) => {
   const fastify = Fastify()
   fastify.register(App)
   t.teardown(fastify.close.bind(fastify))
+  await fastify.ready()
 
   const ws = await fastify.injectWS('/', {headers: { "api-key" : "some-random-key" }})
   let resolve;


### PR DESCRIPTION
Using correct variable instead of variable that didn't exist

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
