### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { IncomingMessage, ServerResponse, Server } from 'http';
+import { IncomingMessage, ServerResponse, Server } from 'node:http';
 import { FastifyRequest, FastifyPluginCallback, RawServerBase, RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, RequestGenericInterface, ContextConfigDefault, FastifyInstance, FastifySchema, FastifyTypeProvider, FastifyTypeProviderDefault, FastifyBaseLogger } from 'fastify';
 import * as fastify from 'fastify';
 import * as WebSocket from 'ws';


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.