### PR TITLE
Handle cases where the socket has already been assigned to the request

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,9 @@ function fastifyWebsocket (fastify, opts, next) {
     rawRequest[kWsHead] = head
     const rawResponse = new ServerResponse(rawRequest)
     try {
-      rawResponse.assignSocket(socket)
+      if (!rawResponse.socket) {
+        rawResponse.assignSocket(socket)
+      }
       fastify.routing(rawRequest, rawResponse)
     } catch (err) {
       fastify.log.warn({ err }, 'websocket upgrade failed')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Bun 1.2.6 introduced a ton of changes to websocket handling.  As part of those changes, sockets now seem to already be assigned to the response prior to fastify-websocket attempting to assign it.  The specific error it results in is:

```
[08:29:49.659] WARN (95250): websocket upgrade failed
    err: {
      "type": "Error",
      "message": "Socket already assigned",
      "stack":
          Error: Socket already assigned
              at unknown
              at assignSocket (node:http:1275:31)
              at onUpgrade (/Users/justin/Projects/test-project/node_modules/@fastify/websocket/index.js:114:19)
              at emit (node:events:95:22)
              at onNodeHTTPRequest (node:http:558:24)
      "name": "Error",
      "code": "ERR_HTTP_SOCKET_ASSIGNED"
    }

```

All this change does is conditionally assign the socket to the response if it's not already assigned.

I've tested this with both node and bun and it seems to result in the correct behavior on both now.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
