### PR TITLE
feat: add handleUpgradeRequest route option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ import { preCloseAsyncHookHandler, preCloseHookHandler } from 'fastify/types/hoo
 import { FastifyReply } from 'fastify/types/reply'
 import { RouteGenericInterface } from 'fastify/types/route'
 import { IncomingMessage, Server, ServerResponse } from 'node:http'
+import { Duplex } from 'node:stream'
 import * as WebSocket from 'ws'
 
 interface WebsocketRouteOptions<
@@ -17,6 +18,7 @@ interface WebsocketRouteOptions<
   Logger extends FastifyBaseLogger = FastifyBaseLogger
 > {
   wsHandler?: fastifyWebsocket.WebsocketHandler<RawServer, RawRequest, RequestGeneric, ContextConfig, SchemaCompiler, TypeProvider, Logger>;
+  handleUpgradeRequest?: (request: FastifyRequest<RequestGeneric, RawServer, RawRequest, SchemaCompiler, TypeProvider, ContextConfig, Logger>, rawSocket: Duplex, socketHead: Buffer) => Promise<WebSocket.WebSocket>;
 }
 
 declare module 'fastify' {


### PR DESCRIPTION
At [gadget](https://gadget.dev/) we make extensive use of `@fastify/websocket`. One use case is a websocket proxy that connects vite hmr clients in the browser to a developers serverless development environment. The vite client has a ping protocol with the following semantics:

1. If the vite dev server listening then the hmr endpoint should upgrade the connection and immediately close
2. If the vite dev server isn't listening yet the endpoint should reject the connection https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/ws.ts#L258-L263

We need a way to handle upgrade events in our proxy layer and not upgrade connections until we know that the upstream vite will also upgrade the connection. To do this I have introduced a route level option `handleUpgradeRequest` that allows for a route by route customization of how the upgrade event should be handled.

`handleUpgradeRequest` is a function that takes the incoming `FastifyRequest`, the source socket and the head buffer; to continue through to the normal `wsHandler` the use should return a promise that resolves to a connected websocket; to reject the connection the user can either throw an error (optionally with a `statusCode`) or write directly to/teardown the source socket

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
