### PR TITLE
docs: clarify which hooks run for websocket routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ fastify.get('/*', { websocket: true }, (socket, request) => {
 ```
 ### Using hooks
 
-Routes registered with `@fastify/websocket` respect the Fastify plugin encapsulation contexts, and so will run any hooks that have been registered. This means the same route hooks you might use for authentication or error handling of plain old HTTP handlers will apply to websocket handlers as well.
+Routes registered with `@fastify/websocket` respect the Fastify plugin encapsulation contexts. Hooks that run **before** the websocket connection is established will be called - this includes `onRequest`, `preParsing`, `preValidation`, and `preHandler`. These hooks can be used for authentication or other request-level processing.
+
+However, hooks related to response serialization and transmission (`preSerialization`, `onSend`) **do not run** for websocket routes. Once the connection is upgraded, message handling is outside Fastify's HTTP lifecycle. If you need to transform outgoing websocket messages, implement that logic in your handler before calling `socket.send()`.
 
 ```js
 fastify.addHook('preValidation', async (request, reply) => {


### PR DESCRIPTION
The current "Using hooks" section says that hooks "will run" but doesn't specify which hooks actually apply to websocket routes. I ran into the same issue as #203 where I expected `onSend` to fire for websocket message handling.

After reading through the discussion, the consensus was:
- Pre-connection hooks (`onRequest`, `preParsing`, `preValidation`, `preHandler`) run normally since they execute before the websocket upgrade
- Response hooks (`preSerialization`, `onSend`) don't apply because once the connection upgrades, message handling bypasses Fastify's HTTP response lifecycle

I updated the documentation to make this distinction clear, including a note on how to handle message transformation if needed.

Closes #203
