### PR TITLE
fix: route raw socket 'error' events through the errorHandler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ fastify.listen({ port: 3000 }, err => {
 
 ### Custom error handler:
 
-You can optionally provide a custom `errorHandler` that will be used to handle any cleaning up of established websocket connections. The `errorHandler` will be called if any errors are thrown by your websocket route handler after the connection has been established. Note that neither Fastify's `onError` hook or functions registered with `fastify.setErrorHandler` will be called for errors thrown during a websocket request handler.
+You can optionally provide a custom `errorHandler` that will be used to handle any cleaning up of established websocket connections. The `errorHandler` will be called if any errors are thrown by your websocket route handler after the connection has been established, as well as for `error` events emitted by the established websocket connection itself (for example when a client disconnects uncleanly), so applications can classify expected disconnect errors instead of having them logged unconditionally at the error level. Note that neither Fastify's `onError` hook or functions registered with `fastify.setErrorHandler` will be called for errors thrown during a websocket request handler.
 
 Neither the `errorHandler` passed to this plugin or fastify's `onError` hook will be called for errors encountered during message processing for your connection. If you want to handle unexpected errors within your `message` event handlers, you'll need to use your own `try { } catch {}` statements and decide what to send back over the websocket.
 

--- a/index.js
+++ b/index.js
@@ -127,10 +127,6 @@ function fastifyWebsocket (fastify, opts, next) {
     wss.handleUpgrade(rawRequest, rawRequest[kWs], rawRequest[kWsHead], (socket) => {
       wss.emit('connection', socket, rawRequest)
 
-      socket.on('error', (error) => {
-        fastify.log.error(error)
-      })
-
       callback(socket)
     })
   }
@@ -189,6 +185,14 @@ function fastifyWebsocket (fastify, opts, next) {
       if (request.raw[kWs]) {
         reply.hijack()
         handleUpgrade(request.raw, socket => {
+          // Errors emitted on the established socket (e.g. an unclean client
+          // disconnect) are routed through the errorHandler so applications
+          // can classify them, and so the socket always has an 'error'
+          // listener attached.
+          socket.on('error', (error) => {
+            errorHandler.call(this, error, socket, request, reply)
+          })
+
           let result
           try {
             if (isWebsocketRoute) {

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -182,6 +182,47 @@ test('Should run custom errorHandler on error inside async websocket handler', a
   await p
 })
 
+test('Should run custom errorHandler when the raw socket emits an error', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  let _resolve
+  const p = new Promise((resolve) => {
+    _resolve = resolve
+  })
+
+  await fastify.register(fastifyWebsocket, {
+    errorHandler: function (error, socket, request, reply) {
+      t.assert.deepStrictEqual(error.code, 'WS_ERR_UNEXPECTED_RSV_2_3')
+      t.assert.deepStrictEqual(request.ws, true)
+      socket.terminate()
+      _resolve()
+    }
+  })
+
+  fastify.get('/', { websocket: true }, () => {})
+
+  await fastify.listen({ port: 0 })
+
+  const client = new WebSocket('ws://localhost:' + fastify.server.address().port)
+  t.after(() => {
+    if (client.readyState) {
+      client.close()
+    }
+  })
+
+  await once(client, 'open')
+
+  // Write an invalid frame directly to the underlying TCP socket so the
+  // server-side websocket emits an 'error' event after the connection is
+  // established.
+  client._socket.write(Buffer.from([0xa2, 0x00]))
+
+  await p
+})
+
 test('Should be able to pass custom options to ws', async (t) => {
   t.plan(2)
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -330,13 +330,23 @@ test('Should invoke the correct handler depending on the headers', (t, end) => {
 
     const wsClient = net.createConnection({ port }, () => {
       wsClient.write('GET / HTTP/1.1\r\nConnection: upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n')
-      wsClient.once('data', data => {
-        t.assert.match(data.toString(), /hi from wsHandler/i)
+      // The 101 response and the first websocket frame are separate writes, so
+      // they can arrive in separate chunks; accumulate instead of asserting on
+      // the first chunk only.
+      let received = ''
+      const onData = data => {
+        received += data.toString()
+        if (!/hi from wsHandler/i.test(received)) {
+          return
+        }
+        wsClient.removeListener('data', onData)
+        t.assert.match(received, /hi from wsHandler/i)
         wsClient.end(() => {
           t.assert.ok(true)
           setTimeout(end, 100)
         })
-      })
+      }
+      wsClient.on('data', onData)
     })
   })
 })


### PR DESCRIPTION
#### What

Errors emitted on the established websocket (e.g. `ERR_STREAM_PREMATURE_CLOSE` / `ECONNRESET` from a client disconnecting uncleanly) were caught by a listener hardcoded in `handleUpgrade` that logged unconditionally via `fastify.log.error`, so the `errorHandler` plugin option could never see them and applications had no supported way to classify expected disconnect errors.

This PR removes the hardcoded listener and attaches it in the route handler instead, where the fastify `request`/`reply` are in scope, invoking `errorHandler` with the same `(error, socket, request, reply)` signature already used when a `wsHandler` throws or rejects. The listener is still attached before the user's handler runs, so the socket always has an `'error'` listener and the existing Node.js crash protection is preserved. The default `errorHandler` behavior (log + `socket.terminate()`) is safe for an already-errored socket.

#### Checklist

- [x] failing test added first (uses the suite's existing invalid-frame trigger), passes with the fix
- [x] full suite green with 100% coverage, tstyche type tests pass, lint clean
- [x] README `errorHandler` section updated

Closes #371
